### PR TITLE
Handle paginated results without recursion

### DIFF
--- a/harborapi/client.py
+++ b/harborapi/client.py
@@ -2522,7 +2522,8 @@ class HarborAsyncClient:
         """Bad workaround in order to have a cleaner API for text/plain responses."""
         headers = headers or {}
         headers.update({"Accept": "text/plain"})
-        resp = await self._get(path, params=params, headers=headers, **kwargs)
+        resp, _ = await self._get(path, params=params, headers=headers, **kwargs)
+        # assume text is never paginated
         return resp  # type: ignore
 
     # TODO: refactor this method so it looks like the other methods, while still supporting pagination.

--- a/harborapi/utils.py
+++ b/harborapi/utils.py
@@ -62,9 +62,16 @@ def get_credentials(username: str, secret: str) -> str:
     return b64encode(f"{username}:{secret}".encode("utf-8")).decode("utf-8")
 
 
-def parse_pagination_url(url: str) -> str:
+def parse_pagination_url(url: str) -> Optional[str]:
     """Parse pagination URL and return the next URL"""
     # Formatting: '</api/v2.0/endpoint?page=X&page_size=Y>; rel="next"'
+    if 'rel="next"' not in url:
+        # abnormal case, log warning and return None
+        logger.warning("No next page found in pagination URL: {}", url)
+        return None
+    if 'rel="prev"' in url:
+        return None  # this is normal, and should not be logged
+
     url = url.split(";")[0].strip("><")
     u = url.split("/", 3)  # remove /api/v2.0/
     return "/" + u[-1]  # last segment is the next URL

--- a/harborapi/utils.py
+++ b/harborapi/utils.py
@@ -62,14 +62,28 @@ def get_credentials(username: str, secret: str) -> str:
     return b64encode(f"{username}:{secret}".encode("utf-8")).decode("utf-8")
 
 
-def parse_pagination_url(url: str) -> Optional[str]:
-    """Parse pagination URL and return the next URL"""
+def parse_pagination_url(url: str, ignore_prev: bool = True) -> Optional[str]:
+    """Parse pagination URL and return the next URL
+
+    Parameters
+    ----------
+    url : str
+        The pagination URL to parse
+    ignore_prev : bool
+        Whether to return `None` if the URL relation is `prev`
+
+
+    Returns
+    -------
+    Optional[str]
+        The next URL, or `None` if the URL relation is `prev` and `ignore_prev` is `True`
+    """
     # Formatting: '</api/v2.0/endpoint?page=X&page_size=Y>; rel="next"'
     if 'rel="next"' not in url:
         # abnormal case, log warning and return None
         logger.warning("No next page found in pagination URL: {}", url)
         return None
-    if 'rel="prev"' in url:
+    if ignore_prev and 'rel="prev"' in url:
         return None  # this is normal, and should not be logged
 
     url = url.split(";")[0].strip("><")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -99,7 +99,7 @@ async def test_get_pagination_mock(
 async def test_get_pagination_large_mock(
     async_client: HarborAsyncClient, httpserver: HTTPServer
 ):
-    """Test pagination with a large number of pages (200)."""
+    """Test pagination with a large number of pages."""
     httpserver.expect_oneshot_request("/api/v2.0/users").respond_with_json(
         [{"username": "user1"}],
         headers={"link": '</api/v2.0/users?page=2>; rel="next"'},

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -99,12 +99,12 @@ async def test_get_pagination_mock(
 async def test_get_pagination_large_mock(
     async_client: HarborAsyncClient, httpserver: HTTPServer
 ):
-    """Test pagination with a large number of pages (100)."""
+    """Test pagination with a large number of pages (200)."""
     httpserver.expect_oneshot_request("/api/v2.0/users").respond_with_json(
         [{"username": "user1"}],
         headers={"link": '</api/v2.0/users?page=2>; rel="next"'},
     )
-    N_PAGES = 100
+    N_PAGES = 200
     for page in range(2, N_PAGES + 1):
         if page == N_PAGES:
             headers = None
@@ -117,7 +117,7 @@ async def test_get_pagination_large_mock(
     async_client.url = httpserver.url_for("/api/v2.0")
     users = await async_client.get("/users")  # type: ignore
     assert isinstance(users, list)
-    assert len(users) == 100
+    assert len(users) == N_PAGES
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request makes it so `HarborAsyncClient._get()` can optionally return a `next_link`, which `HarborAsyncClient.get()` can then use to fetch subsequent paginated results, eliminating the need for `_get()` to recursively call itself with the `next_link` as the path argument.

By not relying on recursion, we no longer risk hitting the recursion limit for large or heavily partitioned queries.
