### PR TITLE
Add vulnerability querying/filtering methods

### DIFF
--- a/harborapi/__init__.py
+++ b/harborapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 
 from .client import HarborAsyncClient
 from .client_sync import HarborClient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "harborapi"
-version = "0.1.7"
+version = "0.1.8"
 description = "Async Harbor API v2.0 wrapper"
 readme = "README.md"
 authors = ["Peder Hovdan Andresen <pederhan@usit.uio.no>"]

--- a/tests/models/test_scanner.py
+++ b/tests/models/test_scanner.py
@@ -54,14 +54,20 @@ def test_severity_enum():
 @given(get_hbv_strategy())
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_harborvulnerabilityreport(report: HarborVulnerabilityReport) -> None:
-    report.vulnerabilities.append(
-        VulnerabilityItem(
-            id="CVE-2022-1337-test",
-            description="test-cve",
-            package="test-package",
-        )
+    test_vuln = VulnerabilityItem(
+        id="CVE-2022-1337-test",
+        description="test-cve",
+        package="test-package",
     )
+    report.vulnerabilities.append(test_vuln)
+
+    # Test `has_` methods
     assert report.has_cve("CVE-2022-1337-test")
     assert not report.has_cve("CVE-2022-1337-test2")
     assert report.has_description("test-cve")
     assert report.has_package("test-package")
+
+    # Test `vuln(s)_with_` methods
+    assert report.vuln_with_cve("CVE-2022-1337-test") is test_vuln
+    assert list(report.vulns_with_description("test-cve"))[0] is test_vuln
+    assert list(report.vulns_with_package("test-package"))[0] is test_vuln

--- a/tests/test_harborapi.py
+++ b/tests/test_harborapi.py
@@ -2,4 +2,4 @@ from harborapi import __version__
 
 
 def test_version():
-    assert __version__ == "0.1.7"
+    assert __version__ == "0.1.8"


### PR DESCRIPTION
This pull request adds new methods to `scanner.HarborVulnerabilityReport` that enable querying if the report contains CVEs with specific IDs, affecting certain packages or having certain phrases in their descriptions.