### PR TITLE
Exclude unset fields when serializing

### DIFF
--- a/harborapi/client.py
+++ b/harborapi/client.py
@@ -95,10 +95,15 @@ def model_to_dict(model: BaseModel) -> JSONType:
     """Creates a JSON-serializable dict from a Pydantic model."""
     # Round-trip through BaseModel.json() to ensure that all dict values
     # are JSON-serializable.
+    #
     # Until https://github.com/pydantic/pydantic/issues/1409 is fixed,
     # this is the easiest way to do this without having to implement
     # custom encoders for all Pydantic models.
-    return json.loads(model.json())
+    #
+    # This is of course not ideal, but since we are dealing with network
+    # requests here, this extra encoding should only represent a small
+    # fraction of the overall time spent.
+    return json.loads(model.json(exclude_unset=True))
 
 
 class ResponseLogEntry(NamedTuple):

--- a/tests/endpoints/test_artifacts.py
+++ b/tests/endpoints/test_artifacts.py
@@ -35,7 +35,7 @@ async def test_create_artifact_tag_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/projects/testproj/repositories/testrepo/artifacts/latest/tags",
         method="POST",
-        json=tag.dict(),
+        json=tag.dict(exclude_unset=True),
     ).respond_with_data(
         headers={"Location": expect_location},
         status=status_code,
@@ -246,7 +246,7 @@ async def test_add_artifact_label_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/projects/testproj/repositories/testrepo/artifacts/latest/labels",
         method="POST",
-        json=label.dict(),
+        json=label.dict(exclude_unset=True),
     ).respond_with_data()
     async_client.url = httpserver.url_for("/api/v2.0")
     await async_client.add_artifact_label(

--- a/tests/endpoints/test_artifacts.py
+++ b/tests/endpoints/test_artifacts.py
@@ -12,7 +12,7 @@ from harborapi.models import HarborVulnerabilityReport
 from harborapi.models.buildhistory import BuildHistoryEntry
 from harborapi.models.models import Accessory, Artifact, Label, Tag
 
-from ..strategies.artifact import get_hbv_strategy
+from ..strategies.artifact import artifact_strategy, get_hbv_strategy
 from ..utils import json_from_list
 
 
@@ -210,7 +210,7 @@ async def test_copy_artifact(
 
 
 @pytest.mark.asyncio
-@given(st.lists(st.builds(Artifact)))
+@given(st.lists(artifact_strategy))
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 async def test_get_artifacts_mock(
     async_client: HarborAsyncClient,
@@ -258,7 +258,7 @@ async def test_add_artifact_label_mock(
 
 
 @pytest.mark.asyncio
-@given(st.builds(Artifact))
+@given(artifact_strategy)
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 async def test_get_artifact_mock(
     async_client: HarborAsyncClient,

--- a/tests/endpoints/test_configure.py
+++ b/tests/endpoints/test_configure.py
@@ -61,7 +61,7 @@ async def test_update_config_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/configurations",
         method="PUT",
-        json=config.dict(),
+        json=config.dict(exclude_unset=True),
     ).respond_with_data()
     async_client.url = httpserver.url_for("/api/v2.0")
     await async_client.update_config(config)

--- a/tests/endpoints/test_gc.py
+++ b/tests/endpoints/test_gc.py
@@ -44,7 +44,7 @@ async def test_create_gc_schedule_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/gc/schedule",
         method="POST",
-        json=schedule.dict(),
+        json=schedule.dict(exclude_unset=True),
     ).respond_with_data(
         headers={"Location": expect_location},
         status=201,
@@ -65,7 +65,7 @@ async def test_update_gc_schedule_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/gc/schedule",
         method="PUT",
-        json=schedule.dict(),
+        json=schedule.dict(exclude_unset=True),
     ).respond_with_data()
     await async_client.update_gc_schedule(schedule)
 

--- a/tests/endpoints/test_gc.py
+++ b/tests/endpoints/test_gc.py
@@ -1,4 +1,4 @@
-from contextlib import nullcontext
+import json
 from typing import List
 
 import pytest
@@ -7,15 +7,13 @@ from hypothesis import strategies as st
 from pytest_httpserver import HTTPServer
 
 from harborapi.client import HarborAsyncClient
-from harborapi.exceptions import StatusError
 from harborapi.models.models import GCHistory, Schedule
 
-from ..strategies.artifact import get_hbv_strategy
 from ..utils import json_from_list
 
 
 @pytest.mark.asyncio
-@given(st.builds(Schedule))
+@given(st.builds(Schedule, creation_time=st.datetimes()))
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 async def test_get_gc_schedule_mock(
     async_client: HarborAsyncClient,
@@ -32,7 +30,7 @@ async def test_get_gc_schedule_mock(
 
 
 @pytest.mark.asyncio
-@given(st.builds(Schedule))
+@given(st.builds(Schedule, creation_time=st.datetimes()))
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 async def test_create_gc_schedule_mock(
     async_client: HarborAsyncClient,
@@ -44,7 +42,7 @@ async def test_create_gc_schedule_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/gc/schedule",
         method="POST",
-        json=schedule.dict(exclude_unset=True),
+        json=json.loads(schedule.json(exclude_unset=True)),
     ).respond_with_data(
         headers={"Location": expect_location},
         status=201,

--- a/tests/endpoints/test_oidc.py
+++ b/tests/endpoints/test_oidc.py
@@ -24,7 +24,7 @@ async def test_test_oidc_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/oidc/ping",
         method="POST",
-        json=oidcreq.dict(),
+        json=oidcreq.dict(exclude_unset=True),
     ).respond_with_data(status=status)
     async_client.url = httpserver.url_for("/api/v2.0")
     if status == 200:

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -93,7 +93,7 @@ async def test_create_project_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/projects",
         method="POST",
-        json=project.dict(),
+        json=project.dict(exclude_unset=True),
     ).respond_with_data(headers={"Location": "%2Fapi%2Fv2.0%2Fprojects%2F1234"})
     async_client.url = httpserver.url_for("/api/v2.0")
     resp = await async_client.create_project(project)

--- a/tests/endpoints/test_registries.py
+++ b/tests/endpoints/test_registries.py
@@ -28,7 +28,7 @@ async def test_check_registry_status_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/registries/ping",
         method="POST",
-        json=ping.dict(),
+        json=ping.dict(exclude_unset=True),
     ).respond_with_data()
     async_client.url = httpserver.url_for("/api/v2.0")
     await async_client.check_registry_status(ping)
@@ -93,7 +93,7 @@ async def test_update_registry_mock(
     registry: RegistryUpdate,
 ):
     httpserver.expect_oneshot_request(
-        "/api/v2.0/registries/123", method="PUT", json=registry.dict()
+        "/api/v2.0/registries/123", method="PUT", json=registry.dict(exclude_unset=True)
     ).respond_with_data()
     async_client.url = httpserver.url_for("/api/v2.0")
     await async_client.update_registry(123, registry)
@@ -137,7 +137,7 @@ async def test_create_registry_mock(
     registry: Registry,
 ):
     httpserver.expect_oneshot_request(
-        "/api/v2.0/registries", method="POST", json=registry.dict()
+        "/api/v2.0/registries", method="POST", json=registry.dict(exclude_unset=True)
     ).respond_with_data(headers={"Location": "/api/v2.0/registries/123"})
     async_client.url = httpserver.url_for("/api/v2.0")
     resp = await async_client.create_registry(registry)

--- a/tests/endpoints/test_repositories.py
+++ b/tests/endpoints/test_repositories.py
@@ -38,7 +38,7 @@ async def test_update_repository_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/projects/testproj/repositories/testrepo",
         method="PUT",
-        json=repository.dict(),
+        json=repository.dict(exclude_unset=True),
     ).respond_with_data()
     async_client.url = httpserver.url_for("/api/v2.0")
     await async_client.update_repository(

--- a/tests/endpoints/test_robots.py
+++ b/tests/endpoints/test_robots.py
@@ -23,7 +23,7 @@ async def test_create_robot_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/robots",
         method="POST",
-        json=robot.dict(),
+        json=robot.dict(exclude_unset=True),
     ).respond_with_data(robot_created.json(), content_type="application/json")
     async_client.url = httpserver.url_for("/api/v2.0")
     resp = await async_client.create_robot(robot)
@@ -73,7 +73,7 @@ async def test_update_robot_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/robots/1234",
         method="PUT",
-        json=robot.dict(),
+        json=robot.dict(exclude_unset=True),
     ).respond_with_data()
     async_client.url = httpserver.url_for("/api/v2.0")
     await async_client.update_robot(1234, robot)

--- a/tests/endpoints/test_scanners.py
+++ b/tests/endpoints/test_scanners.py
@@ -127,7 +127,7 @@ async def test_ping_scanner_adapter_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/scanners/ping",
         method="POST",
-        json=settings.dict(),
+        json=settings.dict(exclude_unset=True),
     ).respond_with_data()
     async_client.url = httpserver.url_for("/api/v2.0")
     await async_client.ping_scanner_adapter(settings)
@@ -144,7 +144,7 @@ async def test_update_scanner_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/scanners/1234",
         method="PUT",
-        json=scanner.dict(),
+        json=scanner.dict(exclude_unset=True),
     ).respond_with_data()
     async_client.url = httpserver.url_for("/api/v2.0")
     await async_client.update_scanner(1234, scanner)

--- a/tests/endpoints/test_usergroups.py
+++ b/tests/endpoints/test_usergroups.py
@@ -46,7 +46,7 @@ async def test_create_usergroup_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/usergroups",
         method="POST",
-        json=usergroup.dict(),
+        json=usergroup.dict(exclude_unset=True),
     ).respond_with_data(
         headers={"Location": expect_location},
         status=201,
@@ -67,7 +67,7 @@ async def test_update_usergroup_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/usergroups/123",
         method="PUT",
-        json=usergroup.dict(),
+        json=usergroup.dict(exclude_unset=True),
     ).respond_with_data()
     await async_client.update_usergroup(123, usergroup)
 

--- a/tests/endpoints/test_users.py
+++ b/tests/endpoints/test_users.py
@@ -173,7 +173,7 @@ async def test_create_user_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/users",
         method="POST",
-        json=user.dict(),
+        json=user.dict(exclude_unset=True),
     ).respond_with_data(status=201, headers={"Location": "/api/v2.0/users/1234"})
     async_client.url = httpserver.url_for("/api/v2.0")
     resp = await async_client.create_user(user)
@@ -191,7 +191,7 @@ async def test_update_user_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/users/1234",
         method="PUT",
-        json=user.dict(),
+        json=user.dict(exclude_unset=True),
     ).respond_with_data(status=200)
     async_client.url = httpserver.url_for("/api/v2.0")
     await async_client.update_user(1234, user)

--- a/tests/models/test_scanner.py
+++ b/tests/models/test_scanner.py
@@ -59,7 +59,7 @@ def test_severity_enum():
     assert Severity.medium != Severity.high
 
     # Ensure that the enum values are ordered from least to most severe
-    severities = list(iter(Severity))
+    severities = list(Severity)
     for i, severity in enumerate(severities):
         if i == 0:
             assert severity < severities[i + 1]


### PR DESCRIPTION
When an endpoint method takes a model where optional fields are not set, the method should avoid including the field altogether in the JSON request body.  There might be a semantic difference between excluding a field and including it, but having its value be `null`. In order to not make assumptions about this difference, this pull request makes it so unset fields are excluded when sending requests.

Until all `harborapi`'s endpoint methods have been thoroughly tested with a live Harbor instance, all this is just conjecture, but for now it seems like a reasonable assumption, hence proceeding with this change.

## Tests

Most POST/PUT tests did not expect that fields could be omitted, and they have been changed accordingly.