### PR TITLE
Safer model construction in raw mode

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -293,6 +293,71 @@ async def test_construct_model_raw(
 
 
 @pytest.mark.asyncio
+async def test_construct_model_raw_is_list(
+    async_client: HarborAsyncClient,
+    mocker: MockerFixture,
+):
+    c = async_client
+    c.raw = True
+    construct_spy = mocker.spy(UserResp, "construct")
+    parse_spy = mocker.spy(UserResp, "parse_obj")
+
+    expect_resp = [{"username": "user1", "foo": "bar"}, {"username": "user2"}]
+    m = c.construct_model(UserResp, expect_resp, is_list=True)
+    assert m == expect_resp
+    assert m[0]["username"] == "user1"
+    assert m[0]["foo"] == "bar"
+    assert m[1]["username"] == "user2"
+    assert construct_spy.call_count == 0
+    assert parse_spy.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_construct_model_raw_list_without_is_list(
+    async_client: HarborAsyncClient,
+    mocker: MockerFixture,
+):
+    """Receives list value, but is_list is set to False.
+    Since we are in raw mode, this is not an error.
+    """
+    c = async_client
+    c.raw = True
+    construct_spy = mocker.spy(UserResp, "construct")
+    parse_spy = mocker.spy(UserResp, "parse_obj")
+
+    expect_resp = [{"username": "user1", "foo": "bar"}, {"username": "user2"}]
+    m = c.construct_model(UserResp, expect_resp, is_list=False)
+    assert m == expect_resp
+    assert m[0]["username"] == "user1"
+    assert m[0]["foo"] == "bar"
+    assert m[1]["username"] == "user2"
+    assert construct_spy.call_count == 0
+    assert parse_spy.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_construct_model_raw_is_list_without_list(
+    async_client: HarborAsyncClient,
+    mocker: MockerFixture,
+):
+    """is_list is set to True, but receives non-list value.
+    Since we are in raw mode, this is not an error.
+    """
+    c = async_client
+    c.raw = True
+    construct_spy = mocker.spy(UserResp, "construct")
+    parse_spy = mocker.spy(UserResp, "parse_obj")
+
+    expect_resp = {"username": "user1", "foo": "bar"}
+    m = c.construct_model(UserResp, expect_resp, is_list=True)
+    assert m == expect_resp
+    assert m["username"] == "user1"
+    assert m["foo"] == "bar"
+    assert construct_spy.call_count == 0
+    assert parse_spy.call_count == 0
+
+
+@pytest.mark.asyncio
 async def test_get_invalid_data(
     async_client: HarborAsyncClient, httpserver: HTTPServer
 ):


### PR DESCRIPTION
This pull request changes the way `HarborAsyncClient.construct_model()` works by adding a new `is_list` parameter, which internally iteratively calls  a new `HarborAsyncClient._construct_model()` method, which performs the actual model construction. Furthermore, all methods that previously called `construct_model()` within a list comprehension have been changed to call it once, but now with the new `is_list` parameter.

## Rationale

The benefit of this is that when the new raw mode is enabled, we completely evade all logic that deals with assumptions about the shape of the data. When `construct_model()` is called in raw mode, it immediately returns whatever it received.

https://github.com/pederhan/harborapi/blob/3edfd4a9790498cd6c8b47babe15761f1837330d/harborapi/client.py#L290-L313

Currently, raw mode completely circumvents all type checks, and in the future we could potentially make it type safe by adding another overload with a generic type for the `data` argument of `construct_model()`.