### PR TITLE
Restrict httpx exception types to trigger backoff for

### DIFF
--- a/harborapi/client.py
+++ b/harborapi/client.py
@@ -25,7 +25,13 @@ from pydantic import BaseModel, ValidationError
 
 from ._types import JSONType
 from .auth import load_harbor_auth_file, new_authfile_from_robotcreate
-from .exceptions import BadRequest, HarborAPIException, NotFound, check_response_status
+from .exceptions import (
+    RETRY_ERRORS,
+    BadRequest,
+    HarborAPIException,
+    NotFound,
+    check_response_status,
+)
 from .models import (
     Accessory,
     Artifact,
@@ -3404,7 +3410,7 @@ class HarborAsyncClient:
         base_headers.update(headers)  # Override defaults with provided headers
         return base_headers
 
-    @backoff.on_exception(backoff.expo, RequestError, max_time=30)
+    @backoff.on_exception(backoff.expo, RETRY_ERRORS, max_time=30)
     async def get(
         self,
         path: str,
@@ -3464,7 +3470,7 @@ class HarborAsyncClient:
 
         return j
 
-    @backoff.on_exception(backoff.expo, RequestError, max_time=30)
+    @backoff.on_exception(backoff.expo, RETRY_ERRORS, max_time=30)
     async def get_text(
         self,
         path: str,
@@ -3527,7 +3533,7 @@ class HarborAsyncClient:
         return j, None
 
     # NOTE: POST is not idempotent, should we still retry?
-    @backoff.on_exception(backoff.expo, RequestError, max_tries=1)
+    @backoff.on_exception(backoff.expo, RETRY_ERRORS, max_tries=1)
     async def post(
         self,
         path: str,
@@ -3562,7 +3568,7 @@ class HarborAsyncClient:
         check_response_status(resp)
         return resp
 
-    @backoff.on_exception(backoff.expo, RequestError, max_time=30)
+    @backoff.on_exception(backoff.expo, RETRY_ERRORS, max_time=30)
     async def put(
         self,
         path: str,
@@ -3601,7 +3607,7 @@ class HarborAsyncClient:
         check_response_status(resp)
         return resp
 
-    @backoff.on_exception(backoff.expo, RequestError, max_time=30)
+    @backoff.on_exception(backoff.expo, RETRY_ERRORS, max_time=30)
     async def patch(
         self,
         path: str,
@@ -3641,7 +3647,7 @@ class HarborAsyncClient:
         check_response_status(resp)
         return resp
 
-    @backoff.on_exception(backoff.expo, RequestError, max_time=30)
+    @backoff.on_exception(backoff.expo, RETRY_ERRORS, max_time=30)
     async def delete(
         self,
         path: str,
@@ -3677,7 +3683,7 @@ class HarborAsyncClient:
         self.log_response(resp)
         return resp
 
-    @backoff.on_exception(backoff.expo, RequestError, max_time=30)
+    @backoff.on_exception(backoff.expo, RETRY_ERRORS, max_time=30)
     async def head(
         self,
         path: str,

--- a/harborapi/exceptions.py
+++ b/harborapi/exceptions.py
@@ -1,11 +1,19 @@
 from typing import Any, List, Optional
 
-from httpx import HTTPStatusError, Response
+from httpx import HTTPStatusError, NetworkError, Response, TimeoutException
 from loguru import logger
 
 from harborapi.utils import is_json
 
 from .models import Error, Errors
+
+# NOTE: this should probably be configurable somehow
+# However, backoff.on_retry needs to receive a TUPLE of exception types
+# (despite claiming it can be a sequence), so it can't be a list
+RETRY_ERRORS = [
+    TimeoutException,
+    NetworkError,
+]
 
 
 class HarborAPIException(Exception):

--- a/harborapi/exceptions.py
+++ b/harborapi/exceptions.py
@@ -10,10 +10,10 @@ from .models import Error, Errors
 # NOTE: this should probably be configurable somehow
 # However, backoff.on_retry needs to receive a TUPLE of exception types
 # (despite claiming it can be a sequence), so it can't be a list
-RETRY_ERRORS = [
+RETRY_ERRORS = (
     TimeoutException,
     NetworkError,
-]
+)
 
 
 class HarborAPIException(Exception):


### PR DESCRIPTION
Currently, we trigger backoff for any [`httpx.RequestError`](https://www.python-httpx.org/exceptions/), but that's too broad, as it would trigger the full backoff duration for sending a request with an unsupported protocol (missing "http(s)://" for example).

To remedy this, a new `RETRY_ERRORS` variable has been added to `harborapi.exceptions`, which is a tuple of exception types to handle. This tuple of exceptions contains a stricter subset of `httpx.RequestError` types, which are more sensible as defaults.

This is just a stepping stone on the way to implementing #25, and once that's in place, the types of exceptions to handle can be fully configured by the user themselves.

## Sidenote

`backoff.on_exception` claims to accept any sequence of exception types, but once you actually inspect the source code, you can see that it needs to be a _tuple_ of exception types. If we keep using backoff, we could consider submitting a pull request to remedy this.