### PR TITLE
Fix pagination URLs with spaces

### DIFF
--- a/harborapi/utils.py
+++ b/harborapi/utils.py
@@ -184,7 +184,7 @@ def get_basicauth(username: str, secret: str) -> SecretStr:
 
 # Finds the next url in a pagination header (e.g. Link: </api/v2.0/endpoint?page=X&page_size=Y>; rel="next")
 # Ripped from: https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api?apiVersion=2022-11-28#example-creating-a-pagination-method
-PAGINATION_NEXT_PATTERN = re.compile(r"(?<=<)([\S]*)(?=>; rel=\"next\")")
+PAGINATION_NEXT_PATTERN = re.compile('<([^>]+)>; rel="next"')
 
 # Finds the API path in a URL (e.g. /api/v2.0/)
 API_PATH_PATTERN = re.compile(r"\/api\/v[0-9]\.[0-9]{1,2}")
@@ -210,7 +210,7 @@ def parse_pagination_url(url: str, strip: bool = True) -> Optional[str]:
     if not match:
         return None
 
-    m = match.group(0)
+    m = match.group(1)  # exclude rel="next" from the match
     if not strip:
         return m
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -202,6 +202,16 @@ def test_urldecode_header(header: Dict[str, str], key: str, expected: str):
             '</projects?page=3&page_size=10&sort=resource_type,op_time&with_detail=true>; rel="next"',
             "/projects?page=3&page_size=10&sort=resource_type,op_time&with_detail=true",
         ),
+        # Next link with advanced query string (union relationship)
+        (
+            '</api/v2.0/audit-logs?page=2&page_size=10&q=operation={push pull},resource_type=artifact>; rel="next"',
+            "/audit-logs?page=2&page_size=10&q=operation={push pull},resource_type=artifact",
+        ),
+        # Next link with advanced query string (intersection relationship)
+        (
+            '</api/v2.0/audit-logs?page=2&page_size=10&q=operation=(push pull),resource_type=artifact>; rel="next"',
+            "/audit-logs?page=2&page_size=10&q=operation=(push pull),resource_type=artifact",
+        ),
     ],
 )
 def test_parse_pagination_url(url: str, expected: Optional[str]) -> None:
@@ -235,6 +245,16 @@ def test_parse_pagination_url(url: str, expected: Optional[str]) -> None:
         (
             '</projects?page=3&page_size=10&sort=resource_type,op_time&with_detail=true>; rel="next"',
             "/projects?page=3&page_size=10&sort=resource_type,op_time&with_detail=true",
+        ),
+        # Next link with advanced query string (union relationship)
+        (
+            '</api/v2.0/audit-logs?page=2&page_size=10&q=operation={push pull},resource_type=artifact>; rel="next"',
+            "/api/v2.0/audit-logs?page=2&page_size=10&q=operation={push pull},resource_type=artifact",
+        ),
+        # Next link with advanced query string (intersection relationship)
+        (
+            '</api/v2.0/audit-logs?page=2&page_size=10&q=operation=(push pull),resource_type=artifact>; rel="next"',
+            "/api/v2.0/audit-logs?page=2&page_size=10&q=operation=(push pull),resource_type=artifact",
         ),
     ],
 )


### PR DESCRIPTION
Closes #36. Implements a new regex pattern `<([^>]+)>; rel="next"`, suggested by ChatGPT. All existing tests pass + new test have been added that include the problematic link headers.