### PR TITLE
Configurable retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ The **third number** is the patch version (bug fixes)
 
 <!-- changelog follows -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Configurable retrying of failed requests using the new `RetrySettings` class, which can be passed to the `HarborAsyncClient` constructor with the `retry` keyword argument. See the [retry docs](https://pederhan.github.io/harborapi/usage/retry/) for more information.
 
 ## [0.16.2](https://github.com/pederhan/harborapi/tree/harborapi-v0.16.2) - 2023-04-26
 

--- a/docs/reference/retry.md
+++ b/docs/reference/retry.md
@@ -1,0 +1,8 @@
+# harborapi.retry
+
+::: harborapi.retry
+    options:
+        merge_init_into_class: false
+        show_if_no_docstring: true
+        show_source: true
+        show_bases: true

--- a/docs/usage/retry.md
+++ b/docs/usage/retry.md
@@ -161,7 +161,9 @@ RetrySettings(
 
 ### Wait generators
 
-In the example we define the custom wait generator function `adder`, which takes the arguments `base` and `value`. These parameters both have the default value `1`. However, we can override the default arguments by passing them to the `RetrySettings` constructor as keyword arguments. Any extra keyword arguments passed to the `RetrySettings` constructor will be passed to the wait generator function:
+In the example we define the custom wait generator function `adder`, which takes the arguments `base` and `value`. These parameters both have the default value `1`. If we want to, we can override the default arguments by passing them to the `RetrySettings` constructor as keyword arguments.
+
+Any extra keyword arguments passed to the `RetrySettings` constructor will in turn be passed to the wait generator function:
 
 ```py
 RetrySettings(
@@ -171,7 +173,7 @@ RetrySettings(
 )
 ```
 
-In the example we passed in `base=1` and `value=2`, which means that internally `adder` is called like this:
+Internally, `adder` uses the extra kwargs and is called like this:
 
 ```py
 adder(base=1, value=2)

--- a/docs/usage/retry.md
+++ b/docs/usage/retry.md
@@ -19,6 +19,22 @@ client = HarborAsyncClient(
 )
 ```
 
+The configuration can be changed at any time by modifying the `retry` attribute on the client object.
+
+```py
+client.retry.max_tries = 10
+client.max_time = 300
+```
+
+Or by replacing it altogether:
+
+```py
+client.retry = RetrySettings(
+    max_tries=10,
+    max_time=300,
+)
+```
+
 
 ## Disabling retry
 

--- a/docs/usage/retry.md
+++ b/docs/usage/retry.md
@@ -1,0 +1,40 @@
+# Retry
+
+The client supports retrying requests that fail due to network errors or server errors. This is useful for handling intermittent network issues or server issues.
+
+## Basic configuration
+
+Retrying is enabled by default, and uses exponential backoff to retry requests for up to a minute. The behavior of the retry functionality can be customized by passing a `RetrySettings` object to the client constructor.
+
+```py
+from harborapi import HarborAsyncClient
+from harborapi.retry import RetrySettings
+
+client = HarborAsyncClient(
+    ...,
+    retry=RetrySettings(
+        max_retries=5,
+        max_time=120,
+    ),
+)
+```
+
+
+## Disabling retry
+
+We can also disable retrying by passing `retry=None` to the client constructor.
+
+```py
+from harborapi import HarborAsyncClient
+
+client = HarborAsyncClient(
+    ...,
+    retry=None,
+)
+```
+
+## Advanced Configuration
+
+[`RetrySettings`][harborapi.retry.RetrySettings] supports a wide range of configuration options:
+
+```

--- a/docs/usage/retry.md
+++ b/docs/usage/retry.md
@@ -127,6 +127,8 @@ The `exception` field takes a single exception type or a tuple of exception type
 By default, all network and timeout errors are retried, but no HTTP errors (301, 404, 500, etc.) are retried. We can change this behavior by passing a tuple of HTTP error types to the `exception` field with the HTTP status errors we want to retry:
 
 ```py
+from harborapi.exceptions import InternalServerError, MethodNotAllowed
+
 RetrySettings(
     exception=(InternalServerError, MethodNotAllowed),
 )

--- a/docs/usage/retry.md
+++ b/docs/usage/retry.md
@@ -1,10 +1,10 @@
 # Retry
 
-The client supports retrying requests that fail due to network errors or server errors. This is useful for handling intermittent network issues or server issues.
+The client supports retrying requests that fail due to network errors or server errors. This is useful for handling intermittent network issues or server issues. The retry functionality is powered by [backoff](https://github.com/litl/backoff). Most of the retry functionality is exposed through the [`RetrySettings`][harborapi.retry.RetrySettings] class, which is used to configure the retry behavior.
 
 ## Basic configuration
 
-Retrying is enabled by default, and uses exponential backoff to retry requests for up to a minute. The behavior of the retry functionality can be customized by passing a `RetrySettings` object to the client constructor.
+Retrying is enabled by default, and uses exponential backoff to retry requests for up to a minute. The behavior of the retry functionality can be customized by passing a [`RetrySettings`][harborapi.retry.RetrySettings] object to the client constructor.
 
 ```py
 from harborapi import HarborAsyncClient
@@ -13,7 +13,7 @@ from harborapi.retry import RetrySettings
 client = HarborAsyncClient(
     ...,
     retry=RetrySettings(
-        max_retries=5,
+        max_tries=5,
         max_time=120,
     ),
 )
@@ -37,4 +37,156 @@ client = HarborAsyncClient(
 
 [`RetrySettings`][harborapi.retry.RetrySettings] supports a wide range of configuration options:
 
+```py
+from typing import Any, Generator
+
+import backoff
+from backoff._typing import Details
+
+from harborapi import HarborAsyncClient
+from harborapi.exceptions import InternalServerError, MethodNotAllowed, StatusError
+from harborapi.retry import RetrySettings
+
+
+def adder(
+    base: float = 1,
+    value: float = 1,
+) -> Generator[float, Any, None]:
+    """Generator that yields a number that increases by a constant value."""
+    # Advance past initial .send() call
+    yield  # type: ignore[misc]
+
+    # just add the factor to the base
+    while True:
+        yield base
+        base += value
+
+
+def giveup_predicate(e: Exception) -> bool:
+    # give up on 404 errors
+    if isinstance(e, StatusError):
+        return e.status_code == 404
+    return False  # don't give up otherwise
+
+
+def on_success(details: Details) -> None:
+    print(f"Success after {details['tries']} tries. Elapsed: {details['elapsed']}s")
+
+
+def on_giveup(details: Details) -> None:
+    print(f"Giving up calling {details['target']} after {details['tries']} tries.")
+    # can raise here
+
+
+def on_backoff(details: Details) -> None:
+    # NOTE: only on_backoff has the "wait" key in details
+    print(
+        f"Backing off calling {details['target']} after {details['tries']} tries for {details['wait']}s."
+    )
+
+
+client = HarborAsyncClient(
+    ...,
+    retry=RetrySettings(
+        max_tries=5,
+        max_time=20,
+        exception=(InternalServerError, MethodNotAllowed),
+        wait_gen=adder,
+        base=1,  # wait_gen kwarg
+        value=2,  # wait_gen kwarg
+        jitter=backoff.full_jitter,  # default jitter function
+        giveup=giveup_predicate,
+        on_success=on_success,
+        on_backoff=on_backoff,
+        on_giveup=on_giveup,
+        raise_on_giveup=True,
+    ),
+)
 ```
+
+### Exception types
+
+The `exception` field takes a single exception type or a tuple of exception types. If an exception raised by a request is an instance of one of the given exception types, the request will be retried. Other exception types are raised immediately.
+
+By default, all network and timeout errors are retried, but no HTTP errors (301, 404, 500, etc.) are retried. We can change this behavior by passing a tuple of HTTP error types to the `exception` field with the HTTP status errors we want to retry:
+
+```py
+RetrySettings(
+    exception=(InternalServerError, MethodNotAllowed),
+)
+```
+
+#### Status errors
+
+If we want to retry all HTTP errors, we can pass `StatusError` to the `exception` field:
+
+```py
+from harborapi.exceptions import StatusError
+
+RetrySettings(
+    exception=StatusError,
+)
+```
+
+#### Status and network errors
+
+If we also want to retry all status errors _and_ network errors, we can import `NetworkError` and `TimeoutException` from httpx and use them too:
+
+```py
+from httpx import NetworkError, TimeoutException
+from harborapi.exceptions import StatusError
+
+RetrySettings(
+    exception=(StatusError, NetworkError, TimeoutException),
+)
+```
+
+### Wait generators
+
+In the example we define the custom wait generator function `adder`, which takes the arguments `base` and `value`. These parameters both have the default value `1`. However, we can override the default arguments by passing them to the `RetrySettings` constructor as keyword arguments. Any extra keyword arguments passed to the `RetrySettings` constructor will be passed to the wait generator function:
+
+```py
+RetrySettings(
+    wait_gen=adder,
+    base=1,
+    value=2,
+)
+```
+
+In the example we passed in `base=1` and `value=2`, which means that internally `adder` is called like this:
+
+```py
+adder(base=1, value=2)
+```
+
+!!! note
+    In the custom wait generator function `adder`, we account for the fact that `backoff` pumps the generator once before using it by yielding an initial value of `None`. This is consistent with the internal wait generator functions in `backoff` itself, such as [`backoff.expo`](https://github.com/litl/backoff/blob/d82b23c42d7a7e2402903e71e7a7f03014a00076/backoff/_wait_gen.py#L8-L32) and [`backoff.fibo`](https://github.com/litl/backoff/blob/d82b23c42d7a7e2402903e71e7a7f03014a00076/backoff/_wait_gen.py#L64-L83).
+
+### Jitter
+
+The `jitter` field takes a callable that takes a wait value (float) generated by the wait generator and returns a float. The default jitter function is [`backoff.full_jitter`](https://github.com/litl/backoff/blob/d82b23c42d7a7e2402903e71e7a7f03014a00076/backoff/_jitter.py#L18-L28), which jitters the wait value between 0 and the original wait value.
+
+A custom jitter function could look like this:
+
+
+```py
+import random
+
+def custom_jitter(wait: float) -> float:
+    return wait * random.random()
+```
+
+
+### Event handlers
+
+Furthermore, we can define custom event handlers for the `on_success`, `on_backoff` and `on_giveup` events. Event handlers are callback functions that take a `details` argument, which is a dictionary containing information about the current retry attempt. It has the following keys:
+
+* `target`: reference to the function or method being invoked
+* `args`: positional arguments to func
+* `kwargs`: keyword arguments to func
+* `tries`: number of invocation tries so far
+* `elapsed`: elapsed time in seconds so far
+* `wait`: seconds to wait (`on_backoff` handler only)
+
+
+Check Backoff's [event handler documentation](https://github.com/litl/backoff#event-handlers) for more information on how to use the `on_backoff`, `on_giveup` and `on_success` parameters, and the `details` dict.

--- a/harborapi/retry.py
+++ b/harborapi/retry.py
@@ -35,7 +35,7 @@ def DEFAULT_PREDICATE(e: Exception) -> bool:
     return False
 
 
-class RetrySettings(BaseModel, extra=Extra.allow):
+class RetrySettings(BaseModel):
     enabled: bool = True
     # Required argument for backoff.on_exception
     exception: Union[Type[Exception], Tuple[Type[Exception], ...]] = RETRY_ERRORS
@@ -50,6 +50,10 @@ class RetrySettings(BaseModel, extra=Extra.allow):
     on_backoff: Union[_Handler, Iterable[_Handler], None] = None
     on_giveup: Union[_Handler, Iterable[_Handler], None] = None
     raise_on_giveup: bool = True
+
+    class Config:
+        extra = Extra.allow
+        validate_assignment = True
 
     @property
     def wait_gen_kwargs(self) -> Dict[str, Any]:

--- a/harborapi/retry.py
+++ b/harborapi/retry.py
@@ -1,0 +1,109 @@
+import functools
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+)
+
+import backoff
+from backoff._typing import _WaitGenerator
+from httpx import NetworkError, TimeoutException
+from pydantic import BaseModel, validator
+
+if TYPE_CHECKING:
+    from .client import HarborAsyncClient
+
+from typing_extensions import ParamSpec
+
+RETRY_ERRORS = (
+    TimeoutException,
+    NetworkError,
+)
+
+
+ExceptionType = Type[Exception]
+
+
+class RetrySettings(BaseModel):
+    enabled: bool = True
+    # Required arguments for backoff.on_exception
+    wait_gen: _WaitGenerator = backoff.expo
+    exception: Tuple[Type[Exception], ...] = RETRY_ERRORS
+
+    # Optional arguments for backoff.on_exception
+    max_retries: Optional[int] = None
+    max_time: Optional[float] = 60
+    # Arguments passed to wait_gen through **kwargs
+    wait_gen_base: float = 2
+    wait_gen_factor: float = 1
+    wait_gen_max_value: Optional[float] = 120
+    # Override wait_gen_kwargs with a different set of kwargs
+    # if specified, the above three arguments are ignored
+    wait_gen_kwargs_override: Optional[Dict[str, Any]] = None
+
+    @validator("exception", pre=True)
+    def _validate_exception(cls, v: Any) -> Tuple[Type[Exception], ...]:
+        if isinstance(v, type):
+            return (v,)
+        if isinstance(v, Iterable):
+            return tuple(v)
+        raise ValueError(
+            "Expected an exception type or an iterable for exception types"
+        )
+
+    @property
+    def wait_gen_kwargs(self) -> Dict[str, Optional[float]]:
+        if self.wait_gen_kwargs_override:
+            return self.wait_gen_kwargs_override
+        return {
+            "base": self.wait_gen_base,
+            "factor": self.wait_gen_factor,
+            "max_value": self.wait_gen_max_value,
+        }
+
+
+def get_backoff_kwargs(client: "HarborAsyncClient") -> Dict[str, Any]:
+    retry_settings = client.retry
+
+    if not retry_settings or not retry_settings.enabled:
+        return {}
+
+    return dict(
+        wait_gen=retry_settings.wait_gen,
+        exception=retry_settings.exception,
+        max_tries=retry_settings.max_retries,
+        max_time=retry_settings.max_time,
+        **retry_settings.wait_gen_kwargs,
+    )
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def retry() -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Adds retry logic to a method, where the retry settings are taken
+    from the client's retry settings."""
+
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
+        @functools.wraps(func)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            if not args:
+                raise ValueError("Must be applied on a method, not a function.")
+            client = args[0]  # type: HarborAsyncClient # type: ignore
+            if not client.retry or not client.retry.enabled:
+                return func(*args, **kwargs)
+
+            return backoff.on_exception(**get_backoff_kwargs(client))(func)(
+                *args, **kwargs
+            )
+
+        return wrapper
+
+    return decorator

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
           - usage/methods/delete.md
       - usage/exceptions.md
       - usage/validation.md
+      - usage/retry.md
       - usage/responselog.md
       - usage/async-sync.md
       - usage/creating-system-robot.md
@@ -139,6 +140,7 @@ nav:
       - reference/client_sync.md
       - reference/exceptions.md
       - reference/responselog.md
+      - reference/retry.md
       - reference/types.md
       - reference/utils.md
       - "harborapi.models":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "pydantic>=1.9.1",
   "backoff>=2.1.2",
   "loguru>=0.6.0",
+  "typing_extensions>=4.5.0",
 ]
 dynamic = ["version", "readme"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
 import json
 import os
 from pathlib import Path
-from typing import Union
+from typing import Iterable, Union
 
 import pytest
 from _pytest.logging import LogCaptureFixture
 from hypothesis import Verbosity, settings
 from loguru import logger
+from pytest_httpserver import HTTPServer
 
 from harborapi.client import HarborAsyncClient
 
@@ -26,6 +27,17 @@ settings.register_profile(
 )
 settings.register_profile("dev", max_examples=10)
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))
+
+
+@pytest.fixture(scope="function")
+def httpserver(httpserver: HTTPServer) -> Iterable[HTTPServer]:
+    yield httpserver
+    # Ensure server is running after each test
+    if not httpserver.is_running():
+        httpserver.start()  # type: ignore
+    # Ensure server has no handlers after each test
+    httpserver.clear_all_handlers()  # type: ignore
+    # Maybe run .clear() too?
 
 
 # must be set to "function" to make sure logging is enabled for each test

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,179 @@
+import asyncio
+
+import pytest
+from backoff._typing import Details
+from httpx import ConnectError
+from pytest_httpserver import HTTPServer
+
+from harborapi.client import HarborAsyncClient
+from harborapi.exceptions import HarborAPIException, StatusError
+from harborapi.retry import RetrySettings, get_backoff_kwargs
+
+
+def test_retrysettings_basic():
+    retry = RetrySettings(
+        max_tries=5,
+        max_time=120,
+    )
+    assert retry.max_tries == 5
+    assert retry.max_time == 120
+
+
+def test_retrysettings_exception_single():
+    retry = RetrySettings(
+        exception=StatusError,
+    )
+    assert retry.exception == StatusError
+
+
+def test_retrysettings_exception_single_tuple():
+    retry = RetrySettings(
+        exception=(StatusError,),
+    )
+    assert retry.exception == (StatusError,)
+
+
+def test_retrysettings_exception_multiple():
+    retry = RetrySettings(
+        exception=(StatusError, HarborAPIException),
+    )
+    assert retry.exception == (StatusError, HarborAPIException)
+
+
+def test_retrysettings_exception_multiple_list():
+    retry = RetrySettings(
+        exception=[StatusError, HarborAPIException],
+    )
+    assert retry.exception == (StatusError, HarborAPIException)
+
+
+# TODO: fuzz with hypothesis if needed
+def test_get_backoff_kwargs(async_client: HarborAsyncClient) -> None:
+    def wait_gen(value: float) -> float:
+        return 1 + value
+
+    def jitter(value: float) -> float:
+        return value + 1
+
+    def giveup(e: Exception) -> bool:
+        return False
+
+    def on_backoff(details: Details) -> None:
+        pass
+
+    def on_success(details: Details) -> None:
+        pass
+
+    def on_giveup(details: Details) -> None:
+        pass
+
+    retry = RetrySettings(
+        exception=Exception,
+        max_tries=5,
+        max_time=120,
+        wait_gen=wait_gen,
+        jitter=jitter,
+        giveup=giveup,
+        on_success=on_success,
+        on_backoff=on_backoff,
+        on_giveup=on_giveup,
+        raise_on_giveup=False,
+        value=2,
+    )
+    async_client.retry = retry
+
+    kwargs = get_backoff_kwargs(async_client)
+    assert kwargs["exception"] == Exception
+    assert kwargs["max_tries"] == 5
+    assert kwargs["max_time"] == 120
+    assert kwargs["wait_gen"] == wait_gen
+    assert kwargs["jitter"] == jitter
+    assert kwargs["giveup"] == giveup
+    assert kwargs["on_success"] == on_success
+    assert kwargs["on_backoff"] == on_backoff
+    assert kwargs["on_giveup"] == on_giveup
+    assert kwargs["raise_on_giveup"] is False
+    assert kwargs["value"] == 2
+
+
+@pytest.mark.asyncio
+async def test_get_retry_mock(async_client: HarborAsyncClient, httpserver: HTTPServer):
+    """Test retry by mocking a server that is initially down, then comes up."""
+    httpserver.stop()
+
+    # this is a little hacky for now:
+    # we schedule the server to start after a few seconds
+    async def start_server():
+        await asyncio.sleep(2)  # can be increased, but wastes CI run time
+        httpserver.start()
+
+    asyncio.create_task(start_server())
+
+    httpserver.expect_oneshot_request("/api/v2.0/users").respond_with_json(
+        [{"username": "user1"}, {"username": "user2"}],
+    )
+
+    async_client.url = httpserver.url_for("/api/v2.0")
+    users = await async_client.get("/users")
+    assert isinstance(users, list)
+    assert len(users) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_retry_disabled_mock(
+    async_client: HarborAsyncClient, httpserver: HTTPServer
+):
+    """Test that a ConnectError is raised when the server is down and
+    retry is disabled."""
+    httpserver.stop()
+
+    httpserver.expect_oneshot_request("/api/v2.0/users").respond_with_json(
+        [{"username": "user1"}, {"username": "user2"}],
+    )
+
+    async_client.url = httpserver.url_for("/api/v2.0")
+    async_client.retry = None  # disable retry
+    with pytest.raises(ConnectError):
+        users = await async_client.get("/users")
+        assert isinstance(users, list)
+        assert len(users) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_retry_custom_wait_gen(
+    async_client: HarborAsyncClient, httpserver: HTTPServer
+):
+    """Test that a ConnectError is raised when the server is down and
+    retry is disabled."""
+    httpserver.stop()
+
+    async def start_server():
+        await asyncio.sleep(0.5)  # can be increased, but wastes CI run time
+        httpserver.start()
+
+    httpserver.expect_oneshot_request("/api/v2.0/users").respond_with_json(
+        [{"username": "user1"}, {"username": "user2"}],
+    )
+
+    # Simpler than using a mocker object
+    call_count = 0
+
+    def wait_gen():
+        nonlocal call_count
+        yield  # does not count towards call count
+        while True:
+            call_count += 1
+            yield 0.01
+
+    async_client.url = httpserver.url_for("/api/v2.0")
+    async_client.retry.wait_gen = wait_gen
+
+    # First call(s) should fail
+    asyncio.create_task(start_server())
+    users = await async_client.get("/users")
+
+    assert isinstance(users, list)
+    assert len(users) == 2
+    # Generator should have been called more than once
+    # since the first call just initializes it
+    assert call_count >= 1


### PR DESCRIPTION
Closes #25 

This pull request adds the option to configure backoff when instantiating the client.

## Tasks

- [x] Add new module `retry`, which contains the class `RetrySettings` and the `retry()` decorator.w
- [x] Add `retry` arg for `HarborAsyncClient.__init__` which takes a `RetrySettings` or None. Uses default retry settings if omitted.
- [x] ~Add Per-HTTP method configuration.~ Will add later if needed.
- [x] Regression testing to ensure performance impact is trivial. (Should be looked into a tiny bit more.)

### Configurable backoff

Through the new  `harborapi.retry.RetrySettings`, we can configure retry settings on the fly on a per-client basis.