### PR TITLE
Remove loguru dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The **third number** is the patch version (bug fixes)
 
 - `HarborAsyncClient.delete_scanner` now raises `HarborAPIException` if no scanner response is returned from the API (was `UnprocessableEntity` before).
 
+
+### Removed
+
+- Loguru dependency. The library now uses the standard Python logging library for logging purposes. See [Logging](https://pederhan.github.io/harborapi/usage/logging/) in the docs for more information.
+
 ## [0.19.0](https://github.com/pederhan/harborapi/tree/harborapi-v0.19.0) - 2023-05-15
 
 ### Added

--- a/docs/usage/logging.md
+++ b/docs/usage/logging.md
@@ -1,0 +1,46 @@
+# Logging
+
+The library uses the standard Python logging library for logging purposes, and uses a single logger with the name `harborapi`. This logger is disabled by default, but can be enabled if desired.
+
+
+## Enable logging
+
+Logging can be enabled by passing in `logging=True` to the client constructor:
+
+```python hl_lines="7"
+from harborapi import HarborAsyncClient
+
+client = HarborAsyncClient(
+    url="https://harbor.example.com/api/v2.0",
+    username="admin",
+    secret="password",
+    logging=True,
+)
+```
+
+Alternatively, it can be enabled by setting the `HARBORAPI_LOGGING` environment variable to `1`:
+
+```bash
+HARBORAPI_LOGGING=1 python myscript.py
+```
+
+When logging is enabled, the handler will be configured to log to stderr with the log level set to `INFO`.
+
+## Configure logging
+
+Should you wish to configure the logger, you can import it and configure it as you would any other logger:
+
+```python
+import logging
+from harborapi.log import logger
+
+logger.setLevel(logging.DEBUG)
+# ... other changes to the logger
+```
+
+## Limitations
+
+* Currently, the library uses a single logger for all logging purposes. This means that it is not possible to enable logging for only a specific part of the library or individually configure loggers for multiple clients.
+* Configuring logging for one `HarborAsyncClient` instance will affect all other instances, should you have multiple client instances.
+* The library does not support changing the log level through the `HarborAsyncClient` constructor nor env vars. If you wish to change the log level, you must do so through the logger itself. See [Configure logging](#configure-logging) for an example of how to do this.
+* Logging to streams other than stderr is not directly supported through the `HarborAsyncClient` constructor. However, you can configure the logger object to change the handler or add one to log to a different stream.

--- a/docs/usage/logging.md
+++ b/docs/usage/logging.md
@@ -1,6 +1,6 @@
 # Logging
 
-The library uses the standard Python logging library for logging purposes, and uses a single logger with the name `harborapi`. This logger is disabled by default, but can be enabled if desired.
+The library uses the standard Python logging library for logging purposes, and provides a single logger named `harborapi`. The logger is disabled by default, but can be enabled if desired.
 
 
 ## Enable logging

--- a/harborapi/__init__.py
+++ b/harborapi/__init__.py
@@ -1,8 +1,3 @@
-# Disable the loguru logger unless otherwise specified
-from loguru import logger
-
-logger.disable("harborapi")
-
 from . import _types, auth, client, client_sync, exceptions, utils, version
 from .__about__ import __version__ as __version__
 from .client import HarborAsyncClient

--- a/harborapi/exceptions.py
+++ b/harborapi/exceptions.py
@@ -2,10 +2,10 @@ import warnings
 from typing import Any, List, Optional
 
 from httpx import HTTPStatusError, NetworkError, Response, TimeoutException
-from loguru import logger
 
 from harborapi.utils import is_json
 
+from .log import logger
 from .models import Error, Errors
 
 # NOTE: this should probably be configurable somehow
@@ -167,11 +167,11 @@ def check_response_status(
         status_code = response.status_code
         # TODO: remove in v1.0.0
         if missing_ok and status_code == 404:
-            logger.debug("{} not found", response.request.url)
+            logger.warning("%s not found", response.request.url)
             return
         errors = try_parse_errors(response)
-        logger.bind(httpx_err=e, errors=errors).error(
-            "Harbor API returned status code {} for {}",
+        logger.error(
+            "Harbor API returned status code %s for %s",
             response.status_code,
             response.url,
         )
@@ -197,7 +197,7 @@ def try_parse_errors(response: Response) -> Optional[Errors]:
         try:
             return Errors(**response.json())
         except Exception as e:
-            logger.bind(error=e).error(
-                "Failed to parse error response from {} as JSON", response.url
+            logger.error(
+                "Failed to parse error response from %s as JSON: %s", response.url, e
             )
     return None

--- a/harborapi/ext/api.py
+++ b/harborapi/ext/api.py
@@ -15,9 +15,9 @@ from typing import (
 
 import backoff
 from httpx import TimeoutException
-from loguru import logger
 
 from ..exceptions import NotFound
+from ..log import logger
 from ..models import Artifact, Repository, UserResp
 from .artifact import ArtifactInfo
 
@@ -355,7 +355,7 @@ async def run_coros(
     # Create semaphore to limit concurrent connections
     maxconn = max_connections or 0  # semamphore expects an int
     sem = asyncio.Semaphore(maxconn)
-    logger.debug("Running with max connections: {}", maxconn)
+    logger.debug("Running with max connections: %s", maxconn)
 
     # Instead of passing the semaphore to each coroutine, we wrap each coroutine
     # in a function that acquires the semaphore before calling the coroutine.
@@ -391,7 +391,7 @@ async def _get_artifact_report(
     """
     digest = artifact.artifact.digest
     if digest is None:  # should never happen
-        logger.error(f"Artifact {artifact.name_with_tag} has no digest")
+        logger.error(f"Artifact %s has no digest", artifact.name_with_tag)
         return artifact
 
     s = artifact.repository.split_name()
@@ -407,10 +407,11 @@ async def _get_artifact_report(
         digest,
     )
     if report is None:
-        logger.debug(
-            "No vulnerabilities found for artifact '{}'".format(
-                f"{project_name}/{repo_name}@{digest}"
-            )
+        logger.info(
+            "No vulnerabilities found for artifact '%s/%s@%s'",
+            project_name,
+            repo_name,
+            digest,
         )
     else:
         artifact.report = report

--- a/harborapi/ext/regex.py
+++ b/harborapi/ext/regex.py
@@ -3,7 +3,7 @@ import re
 from functools import lru_cache
 from typing import Dict, Optional, Tuple
 
-from loguru import logger
+from ..log import logger
 
 # NOTE: Regex type generics require >=3.9. Have to wrap in a string.
 
@@ -42,5 +42,5 @@ def match(pattern: "re.Pattern[str]", s: str) -> Optional["re.Match[str]"]:
     try:
         return pattern.match(s)
     except Exception as e:
-        logger.error(f"Error matching pattern {pattern} to string {s}: {e}")
+        logger.error(f"Error matching pattern %s to string %s: %s", pattern, s, e)
         return None

--- a/harborapi/ext/stats.py
+++ b/harborapi/ext/stats.py
@@ -2,7 +2,7 @@ import statistics
 from numbers import Number
 from typing import Any, Callable, Iterable
 
-from loguru import logger
+from ..log import logger
 
 __all__ = [
     "mean",
@@ -53,6 +53,6 @@ def _do_stats_math(
     try:
         res = func(a)
     except statistics.StatisticsError:
-        logger.error(f"{func.__name__}({repr(a)}) failed. Defaulting to {default}")
+        logger.error("%s(%s) failed. Defaulting to %s", func.__name__, repr(a), default)
         return float(default)
     return float(res)

--- a/harborapi/log.py
+++ b/harborapi/log.py
@@ -10,10 +10,6 @@ DEFAULT_LEVEL = logging.INFO
 DEFAULT_LEVEL_DISABLED = logging.CRITICAL
 
 logger = logging.getLogger("harborapi")
-logger.setLevel(logging.CRITICAL)  # Disable logging by default
-
-# Add a null handler to prevent "No handler found" warnings
-logger.addHandler(logging.NullHandler())
 
 
 def enable_logging(level: int = DEFAULT_LEVEL) -> None:
@@ -40,6 +36,7 @@ def disable_logging() -> None:
     logger.setLevel(DEFAULT_LEVEL_DISABLED)
     if logger.hasHandlers():
         logger.handlers.clear()  # Remove existing handlers
+    # Add a null handler to prevent "No handler found" warnings
     logger.addHandler(logging.NullHandler())
 
 

--- a/harborapi/log.py
+++ b/harborapi/log.py
@@ -1,0 +1,47 @@
+# I am somewhat clueless about best practices for configuring logging for a library.
+# The contents of this module are derived from a conversation with ChatGPT (GPT-4).
+# NOTE: multiple clients with different `logging` argument values will
+# cause problems. However, users should not be creating multiple clients, so
+# this should not be an issue. If it is, we can add a warning.
+
+import logging
+
+DEFAULT_LEVEL = logging.INFO
+DEFAULT_LEVEL_DISABLED = logging.CRITICAL
+
+logger = logging.getLogger("harborapi")
+logger.setLevel(logging.CRITICAL)  # Disable logging by default
+
+# Add a null handler to prevent "No handler found" warnings
+logger.addHandler(logging.NullHandler())
+
+
+def enable_logging(level: int = DEFAULT_LEVEL) -> None:
+    """Enable logging for 'harborapi'.
+
+    Parameters
+    ----------
+    level : int
+        The logging level, by default logging.INFO
+    """
+    logger.setLevel(level)
+    handler = logging.StreamHandler()  # Logs to stderr by default
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    handler.setFormatter(formatter)
+    if logger.hasHandlers():
+        logger.handlers.clear()  # Remove existing handlers
+    logger.addHandler(handler)
+
+
+def disable_logging() -> None:
+    """Disable logging for 'harborapi'"""
+    logger.setLevel(DEFAULT_LEVEL_DISABLED)
+    if logger.hasHandlers():
+        logger.handlers.clear()  # Remove existing handlers
+    logger.addHandler(logging.NullHandler())
+
+
+# Disable logging by default
+disable_logging()

--- a/harborapi/models/models.py
+++ b/harborapi/models/models.py
@@ -28,9 +28,10 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
-from loguru import logger
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Extra, Field, root_validator
+
+from ..log import logger
 
 # isort kind of mangles these imports by sorting them alphabetically
 # but still splitting each "as _" import into its own line.
@@ -416,7 +417,7 @@ class Repository(_Repository):
         if len(components) != 2:  # no slash in name
             # Shouldn't happen, but we account for it anyway
             logger.warning(
-                "Repository '{}' name is not in the format <project>/<repo>", self.name
+                "Repository name '%s' is not in the format <project>/<repo>", self.name
             )
             return None
         return components[0], components[1]

--- a/harborapi/models/scanner.py
+++ b/harborapi/models/scanner.py
@@ -10,10 +10,10 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Un
 if TYPE_CHECKING:
     from typing import Final  # noqa: F401
 
-from loguru import logger
 from pydantic import Field, validator
 from pydantic.fields import ModelField
 
+from ..log import logger
 from ..version import SemVer, get_semver
 from ._scanner import Artifact as ScanArtifact
 from ._scanner import CVSSDetails, Error, ErrorResponse
@@ -250,7 +250,7 @@ class VulnerabilityItem(_VulnerabilityItem):
                 continue
             elif not isinstance(vendor_cvss, dict):
                 logger.warning(
-                    f"Received non-dict value for vendor CVSS data: {vendor_cvss}"
+                    "Received non-dict value for vendor CVSS data: %s", vendor_cvss
                 )
                 continue
             # NOTE: we can't guarantee these values are floats (dangerous)

--- a/harborapi/utils.py
+++ b/harborapi/utils.py
@@ -5,10 +5,10 @@ from typing import Dict, Mapping, Optional, Union
 from urllib.parse import quote_plus, unquote_plus
 
 from httpx import Response
-from loguru import logger
 from pydantic import SecretStr
 
 from ._types import JSONType, ParamType
+from .log import logger
 
 
 def is_json(response: Response) -> bool:
@@ -59,8 +59,8 @@ def handle_optional_json_response(resp: Response) -> Optional[JSONType]:
     try:
         j = resp.json()
     except JSONDecodeError as e:
-        logger.error("Failed to parse JSON from {}: {}", resp.url, e)
-        raise HarborAPIException("Failed to parse JSON from {}".format(resp.url)) from e
+        logger.error("Failed to parse JSON from %s: %s", resp.url, e)
+        raise HarborAPIException(f"Failed to parse JSON from {resp.url}") from e
     # we assume Harbor API returns dict or list,
     # if not, they are breaking their own schema and that is not our fault
     return j  # type: ignore

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
       - usage/validation.md
       - usage/retry.md
       - usage/responselog.md
+      - usage/logging.md
       - usage/async-sync.md
       - usage/creating-system-robot.md
       - usage/rich.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
   "httpx>=0.23.0",
   "pydantic>=1.9.1",
   "backoff>=2.1.2",
-  "loguru>=0.6.0",
   "typing_extensions>=4.5.0",
 ]
 dynamic = ["version", "readme"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,7 @@ from pathlib import Path
 from typing import Iterable, Union
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 from hypothesis import Verbosity, settings
-from loguru import logger
 from pytest_httpserver import HTTPServer
 
 from harborapi.client import HarborAsyncClient
@@ -49,14 +47,6 @@ def async_client(httpserver: HTTPServer) -> HarborAsyncClient:
         url=httpserver.url_for("/api/v2.0"),
         logging=True,
     )
-
-
-@pytest.fixture
-def caplog(caplog: LogCaptureFixture):
-    # https://loguru.readthedocs.io/en/stable/resources/migration.html#making-things-work-with-pytest-and-caplog
-    handler_id = logger.add(caplog.handler, format="{message}")
-    yield caplog
-    logger.remove(handler_id)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,188 @@
+import logging
+import os
+import warnings
+from typing import Optional
+
+import pytest
+
+from harborapi import HarborAsyncClient
+from harborapi.log import (
+    DEFAULT_LEVEL,
+    DEFAULT_LEVEL_DISABLED,
+    disable_logging,
+    enable_logging,
+    logger,
+)
+
+# TODO: ensure we are testing the logger properly (we are using the global logger object)
+# Should we import logger in each test function?
+
+
+def test_disable_logging(
+    caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture
+) -> None:
+    """Test disable_logging()"""
+    disable_logging()
+
+    # Logger should be set to critical
+    assert logger.level == logging.CRITICAL == DEFAULT_LEVEL_DISABLED
+    assert len(logger.handlers) == 1
+    logger.critical("Test")
+    assert len(caplog.records) == 1  # still captured by caplog
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_enable_logging(
+    caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture
+) -> None:
+    """Test enable_logging()"""
+    disable_logging()  # Make sure we have disabled logging first
+    logger.info("Test 1")
+    assert len(caplog.records) == 0
+
+    # A critical log will not go to stderr, but will create a log record
+    logger.critical("Test 1")
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    # but it actually logs, so we should have 1 record in caplog
+    assert len(caplog.records) == 1
+
+    # Now enable logging
+    enable_logging()
+    assert logger.level == logging.INFO == DEFAULT_LEVEL
+    assert len(logger.handlers) == 1
+    logger.critical("Test 2")
+
+    # We logged a critical log while disabled (but it didnt go to stderr)
+    # So we should have 2 records in caplog
+    assert len(caplog.records) == 2
+    assert caplog.records[1].message == "Test 2"
+    captured = capsys.readouterr()
+    assert "Test 2" in captured.err
+
+
+def test_enable_logging_with_level(
+    caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture
+) -> None:
+    """Test enable_logging() with a custom level"""
+    # Enable logger at debug level
+    enable_logging(level=logging.DEBUG)
+    assert logger.level == logging.DEBUG
+    assert len(logger.handlers) == 1
+    logger.debug("Test 1")
+    assert len(caplog.records) == 1  # logged due to level
+    captured = capsys.readouterr()
+    assert "Test 1" in captured.err
+
+    # Now increase the level and and log with debug again
+    enable_logging(level=logging.INFO)
+    assert logger.level == logging.INFO
+    logger.debug("Test 2")
+    assert len(caplog.records) == 1  # did not log due to level
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_enable_logging_multiple_calls(
+    caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture
+) -> None:
+    # Ensure no warnings are emitted
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        enable_logging()
+        enable_logging()
+        enable_logging()
+
+    logger.info("Test after multiple calls")
+    assert len(caplog.records) == 1
+    captured = capsys.readouterr()
+    assert "Test after multiple calls" in captured.err
+
+
+def test_disable_logging_multiple_calls(
+    caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture
+) -> None:
+    # Ensure no warnings are emitted
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        disable_logging()
+        disable_logging()
+        disable_logging()
+
+    logger.info("Test after multiple calls")
+    assert len(caplog.records) == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize("logging_enabled", [None, False])
+def test_client_logging_disabled(
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture,
+    logging_enabled: Optional[bool],
+) -> None:
+    """Tests client when logging is disabled.
+    Tests by passing in  logging=False and omitting the logging kwarg.
+    Both should keep logging disabled."""
+    kwargs = {"logging": logging_enabled} if logging_enabled is not None else {}
+    HarborAsyncClient(
+        url="https://example.com/api/v2.0", username="test", secret="test", **kwargs
+    )
+    assert logger.level == logging.CRITICAL == DEFAULT_LEVEL_DISABLED
+    assert len(logger.handlers) == 1
+
+    logger.critical("Test critical")
+    logger.info("Test info")
+
+    assert len(caplog.records) == 1  # critical still captured by caplog
+    assert caplog.records[0].message == "Test critical"
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_client_logging_enabled(
+    caplog: pytest.LogCaptureFixture,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Tests client when logging is enabled."""
+    HarborAsyncClient(
+        url="https://example.com/api/v2.0", username="test", secret="test", logging=True
+    )
+    assert logger.level == logging.INFO
+    assert len(logger.handlers) == 1
+
+    logger.critical("Test critical")
+    logger.info("Test info")
+
+    assert len(caplog.records) == 2
+    assert caplog.records[0].message == "Test critical"
+    assert caplog.records[1].message == "Test info"
+    captured = capsys.readouterr()
+    assert "Test critical" in captured.err
+    assert "Test info" in captured.err
+
+
+def test_client_logging_envvar(
+    caplog: pytest.LogCaptureFixture, capsys: pytest.CaptureFixture
+) -> None:
+    assert "HARBORAPI_LOGGING" not in os.environ
+
+    disable_logging()  # Make sure we have disabled logging first (other tests may have enabled it)
+    HarborAsyncClient(url="https://example.com", username="username", secret="secret")
+    assert logger.level == logging.CRITICAL == DEFAULT_LEVEL_DISABLED
+    logger.info("Disabled")
+    assert len(caplog.records) == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+    os.environ["HARBORAPI_LOGGING"] = "1"
+    # Instantiation of the client controls the library logger
+    HarborAsyncClient(url="https://example.com", username="username", secret="secret")
+    assert logger.level == logging.INFO == DEFAULT_LEVEL
+    logger.info("Enabled")
+    assert len(caplog.records) == 1
+    assert caplog.records[0].message == "Enabled"
+    captured = capsys.readouterr()
+
+    os.environ.pop("HARBORAPI_LOGGING")


### PR DESCRIPTION
This PR removes the loguru dependency and re-implements all current log functionality using the standard library `logging` module. A single logger called `"harborapi"` is instantiated in the new `log.py` module, which is then re-used by other modules. This lets us configure and use a single logger for the entire library.

Furthermore, support for a new envvar `HARBORAPI_LOGGING` has been added, which can be used to toggle logging.

New tests have been added to ensure logging works as expected.

Closes #52 