### PR TITLE
Limit pydantic version < 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
   "httpx>=0.23.0",
-  "pydantic>=1.9.1",
+  "pydantic>=1.9.1,<2.0",
   "backoff>=2.1.2",
   "typing_extensions>=4.5.0",
 ]


### PR DESCRIPTION
pydantic 2.0 release has breaking changes which will impact haborapi.  Restrict pydantic version to < 2.0

```
[2023-07-03T01:00:45.909Z]   File "/app/.local/lib/python3.10/site-packages/harborapi/__init__.py", line 1, in <module>
[2023-07-03T01:00:45.909Z]     from . import _types, auth, client, client_sync, exceptions, utils, version
[2023-07-03T01:00:45.909Z]   File "/app/.local/lib/python3.10/site-packages/harborapi/auth.py", line 7, in <module>
[2023-07-03T01:00:45.909Z]     from harborapi.models.models import Robot, RobotCreate, RobotCreated
[2023-07-03T01:00:45.909Z]   File "/app/.local/lib/python3.10/site-packages/harborapi/models/__init__.py", line 1, in <module>
[2023-07-03T01:00:45.909Z]     from . import scanner
[2023-07-03T01:00:45.909Z]   File "/app/.local/lib/python3.10/site-packages/harborapi/models/scanner.py", line 14, in <module>
[2023-07-03T01:00:45.909Z]     from pydantic.fields import ModelField
[2023-07-03T01:00:45.909Z] ImportError: cannot import name 'ModelField' from 'pydantic.fields' (/app/.local/lib/python3.10/site-packages/pydantic/fields.py)
```