### PR TITLE
Update models.py

### DIFF
--- a/harborapi/models/models.py
+++ b/harborapi/models/models.py
@@ -490,7 +490,7 @@ class ReplicationTriggerSettings(BaseModel):
 
 class ReplicationFilter(BaseModel):
     type: Optional[str] = Field(None, description="The replication policy filter type.")
-    value: Optional[Dict[str, Any]] = Field(
+    value: Optional[str, Any] = Field(
         None, description="The value of replication policy filter."
     )
     decoration: Optional[str] = Field(


### PR DESCRIPTION
edited the replication filter model to expect a string instead of a dictionary containing a string, which previously caused a failure when calling get_replication_policies