### PR TITLE
Add `verify` parameter for `authenticate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ While the project is still on major version 0, breaking changes may be introduce
 
 <!-- changelog follows -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+## Added
+
+- `verify` parameter for `HarborAsyncClient.authenticate()`.
 
 ## [0.23.1](https://github.com/unioslo/harborapi/tree/harborapi-v0.23.1) - 2024-01-22
 
@@ -277,7 +281,7 @@ Until the official API spec is fixed, this is the best we can do.
 
 ### Added
 
-- `verify` kwarg for `HarborAsyncClient` and `HarborClient` which is passed to the underlying `httpx.AsyncClient`. This is useful for self-signed certificates, or if you want to control the SSL verification yourself. See [httpx documentation](https://www.python-httpx.org/advanced/#ssl-certificates) for more information.
+- `verify` kwarg for `HarborAsyncClient` and `HarborClient` which is passed to the underlying `httpx.AsyncClient`. This is useful for self-signed certificates, or if you want to control the SSL verification yourself. See [httpx documentation](https://www.python-httpx.org/advanced/ssl/) for more information.
 - `harborapi.exceptions.StatusError.response` which holds the HTTPX response object that caused the exception.
 
 ### Fixed


### PR DESCRIPTION
Adds a new parameter `verify` which allows users to control the SSL verification of an existing client instance.