### PR TITLE
Fix replication filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ While the project is still on major version 0, breaking changes may be introduce
 
 <!-- changelog follows -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+## Added
+
+- `verify` parameter for `HarborAsyncClient.authenticate()`.
 
 ## [0.23.1](https://github.com/unioslo/harborapi/tree/harborapi-v0.23.1) - 2024-01-22
 
@@ -277,7 +281,7 @@ Until the official API spec is fixed, this is the best we can do.
 
 ### Added
 
-- `verify` kwarg for `HarborAsyncClient` and `HarborClient` which is passed to the underlying `httpx.AsyncClient`. This is useful for self-signed certificates, or if you want to control the SSL verification yourself. See [httpx documentation](https://www.python-httpx.org/advanced/#ssl-certificates) for more information.
+- `verify` kwarg for `HarborAsyncClient` and `HarborClient` which is passed to the underlying `httpx.AsyncClient`. This is useful for self-signed certificates, or if you want to control the SSL verification yourself. See [httpx documentation](https://www.python-httpx.org/advanced/ssl/) for more information.
 - `harborapi.exceptions.StatusError.response` which holds the HTTPX response object that caused the exception.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,14 @@ While the project is still on major version 0, breaking changes may be introduce
 
 ## Unreleased
 
-## Added
+### Added
 
 - `verify` parameter for `HarborAsyncClient.authenticate()`.
+- New model field: `ProjectMetadata.auto_sbom_generation`
+
+### Fixed
+
+- `ReplicationFilter.value` validation failing due to receiving non-dict value. Now accepts `str`, `dict[str, Any]` and `None`.
 
 ## [0.23.1](https://github.com/unioslo/harborapi/tree/harborapi-v0.23.1) - 2024-01-22
 

--- a/codegen/ast/fragments/main/replicationfilter.py
+++ b/codegen/ast/fragments/main/replicationfilter.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import Dict
+from typing import Union
+
+from pydantic import Field
+
+
+class ReplicationFilter(BaseModel):
+    value: Union[str, Dict[str, Any], None] = Field(
+        None, description="The value of replication policy filter."
+    )

--- a/harborapi/models/models.py
+++ b/harborapi/models/models.py
@@ -437,6 +437,10 @@ class ProjectMetadata(BaseModel):
         None,
         description='Whether scan images automatically when pushing. The valid values are "true", "false".',
     )
+    auto_sbom_generation: Optional[str] = Field(
+        None,
+        description='Whether generating SBOM automatically when pushing a subject artifact. The valid values are "true", "false".',
+    )
     reuse_sys_cve_allowlist: Optional[str] = Field(
         None,
         description='Whether this project reuse the system level CVE allowlist as the allowlist of its own.  The valid values are "true", "false". If it is set to "true" the actual allowlist associate with this project, if any, will be ignored.',
@@ -490,7 +494,7 @@ class ReplicationTriggerSettings(BaseModel):
 
 class ReplicationFilter(BaseModel):
     type: Optional[str] = Field(None, description="The replication policy filter type.")
-    value: Optional[Dict[str, Any]] = Field(
+    value: Union[str, Dict[str, Any], None] = Field(
         None, description="The value of replication policy filter."
     )
     decoration: Optional[str] = Field(
@@ -757,7 +761,7 @@ class Type(Enum):
 class ScheduleObj(BaseModel):
     type: Optional[Type] = Field(
         None,
-        description="The schedule type. The valid values are 'Hourly', 'Daily', 'Weekly', 'Custom', 'Manual', 'None' and 'Schedule'.\n'Manual' means to trigger it right away, 'Schedule' means to trigger it by a specified cron schedule and \n'None' means to cancel the schedule.\n",
+        description="The schedule type. The valid values are 'Hourly', 'Daily', 'Weekly', 'Custom', 'Manual', 'None' and 'Schedule'.\n'Manual' means to trigger it right away, 'Schedule' means to trigger it by a specified cron schedule and\n'None' means to cancel the schedule.\n",
     )
     cron: Optional[str] = Field(
         None, description="A cron expression, a time-based job scheduler."
@@ -2413,7 +2417,8 @@ class Robot(BaseModel):
         None, description="The level of the robot, project or system"
     )
     duration: Optional[int] = Field(
-        None, description="The duration of the robot in days"
+        None,
+        description="The duration of the robot in days, duration must be either -1(Never) or a positive integer",
     )
     editable: Optional[bool] = Field(
         None, description="The editable status of the robot"
@@ -2442,7 +2447,8 @@ class RobotCreate(BaseModel):
     )
     disable: Optional[bool] = Field(None, description="The disable status of the robot")
     duration: Optional[int] = Field(
-        None, description="The duration of the robot in days"
+        None,
+        description="The duration of the robot in days, duration must be either -1(Never) or a positive integer",
     )
     permissions: Optional[List[RobotPermission]] = None
 


### PR DESCRIPTION
Fixes type of `ReplicationFilter.value` which was previously too strict. Also updates all models to the most recent definitions.