### PR TITLE
Remove model field `example` kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ While the project is still on major version 0, breaking changes may be introduce
 
 - `HarborAsyncClient.authenticate(verify=...)` will no longer instantiate a new client object if the `verify` value is identical to current one.
 
+### Removed
+
+- Model field `example` keyword arguments.
+
 
 ## [0.23.3](https://github.com/unioslo/harborapi/tree/harborapi-v0.23.3) - 2024-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ While the project is still on major version 0, breaking changes may be introduce
 
 <!-- ## Unreleased -->
 
+## [0.23.4](https://github.com/unioslo/harborapi/tree/harborapi-v0.23.4) - 2024-03-01
+
+### Changed
+
+- `HarborAsyncClient.authenticate(verify=...)` will no longer instantiate a new client object if the `verify` value is identical to current one.
+
+
 ## [0.23.3](https://github.com/unioslo/harborapi/tree/harborapi-v0.23.3) - 2024-03-01
 
 ### Fixed

--- a/codegen/ast/fragments/scanner/vulnerabilityitem.py
+++ b/codegen/ast/fragments/scanner/vulnerabilityitem.py
@@ -18,7 +18,6 @@ class VulnerabilityItem(BaseModel):
     links: Optional[List[str]] = Field(
         None,
         description="The list of links to the upstream databases with the full description of the vulnerability.\n",
-        example=["https://security-tracker.debian.org/tracker/CVE-2017-8283"],
     )
 
     @field_validator("severity", mode="before")

--- a/codegen/ast/parser.py
+++ b/codegen/ast/parser.py
@@ -195,9 +195,6 @@ models: dict[str, dict[str, list[Modifier]]] = {
                     ctx=ast.Load(),
                 ),
                 description="The severity of the vulnerability.",
-                example=ast.keyword(
-                    arg="example", value=ast.Name(id="Severity.high.value")
-                ),
             ),
         ],
     },

--- a/harborapi/client.py
+++ b/harborapi/client.py
@@ -327,8 +327,6 @@ class HarborAsyncClient:
         # If user want to change SSL verification, we have to reinstantiate the client
         # https://www.python-httpx.org/advanced/ssl/#ssl-configuration-on-client-instances
         if verify is not None and verify != self.verify:
-            # TODO: add abstraction for client instantiation
-            # that can be used in __init__ and here
             self.verify = verify
             self.client = self._get_client()
 

--- a/harborapi/models/scanner.py
+++ b/harborapi/models/scanner.py
@@ -243,9 +243,7 @@ class VulnerabilityItem(BaseModel):
         examples=["1.18.0"],
     )
     severity: Severity = Field(
-        Severity.unknown,
-        description="The severity of the vulnerability.",
-        example=Severity.high.value,
+        Severity.unknown, description="The severity of the vulnerability."
     )
     description: Optional[str] = Field(
         None,
@@ -257,7 +255,6 @@ class VulnerabilityItem(BaseModel):
     links: Optional[List[str]] = Field(
         None,
         description="The list of links to the upstream databases with the full description of the vulnerability.\n",
-        example=["https://security-tracker.debian.org/tracker/CVE-2017-8283"],
     )
     preferred_cvss: Optional[CVSSDetails] = None
     cwe_ids: Optional[List[str]] = Field(


### PR DESCRIPTION
These are a remnant of an older version of datamodel-code-generator that was carried over to the fragments.