### PR TITLE
Remove client URL assignment in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,8 @@ def httpserver(httpserver: HTTPServer) -> Iterable[HTTPServer]:
 
 # must be set to "function" to make sure logging is enabled for each test
 @pytest.fixture(scope="function")
-def async_client(httpserver: HTTPServer) -> HarborAsyncClient:
-    return HarborAsyncClient(
+def async_client(httpserver: HTTPServer) -> Iterable[HarborAsyncClient]:
+    yield HarborAsyncClient(
         username="username",
         secret="secret",
         url=httpserver.url_for("/api/v2.0"),

--- a/tests/endpoints/test_artifacts.py
+++ b/tests/endpoints/test_artifacts.py
@@ -37,7 +37,6 @@ async def test_create_artifact_tag_mock(
     status_code: int,
     tag: Tag,
 ):
-    async_client.url = httpserver.url_for("/api/v2.0")
     expect_location = (
         async_client.url
         + "/api/v2.0/projects/testproj/repositories/testrepo/artifacts/latest/tags/123"
@@ -76,7 +75,7 @@ async def test_get_artifact_vulnerabilities_mock(
         ),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     r = await async_client.get_artifact_vulnerabilities(
         "testproj", "testrepo", "latest"
     )
@@ -99,7 +98,7 @@ async def test_get_artifact_build_history_mock(
         json_from_list(build_history),
         content_type="application/json",
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_artifact_build_history(
         "testproj", "testrepo", "latest"
     )
@@ -120,7 +119,6 @@ async def test_get_artifact_vulnerabilities_empty_mock(
         "/api/v2.0/projects/testproj/repositories/testrepo/artifacts/latest/additions/vulnerabilities",
         method="GET",
     ).respond_with_json({})
-    async_client.url = httpserver.url_for("/api/v2.0")
 
     with pytest.raises(NotFound):
         await async_client.get_artifact_vulnerabilities(
@@ -144,7 +142,6 @@ async def test_get_artifact_vulnerabilities_nondict_mock(
         "/api/v2.0/projects/testproj/repositories/testrepo/artifacts/latest/additions/vulnerabilities",
         method="GET",
     ).respond_with_json([{"MIME_TYPE_HERE": {"foo": "bar"}}])
-    async_client.url = httpserver.url_for("/api/v2.0")
 
     with pytest.raises(UnprocessableEntity):
         await async_client.get_artifact_vulnerabilities(
@@ -167,7 +164,7 @@ async def test_get_artifact_tags_mock(
         json_from_list(tags),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     tags_resp = await async_client.get_artifact_tags("testproj", "testrepo", "latest")
     # TODO: test params
     assert tags_resp == tags
@@ -190,7 +187,7 @@ async def test_get_artifact_accessories_mock(
         json_from_list(accessories),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     accessories_resp = await async_client.get_artifact_accessories(
         "testproj", "testrepo", "latest"
     )
@@ -210,7 +207,7 @@ async def test_delete_artifact_tag(
         "/api/v2.0/projects/testproj/repositories/testrepo/artifacts/latest/tags/123",
         method="DELETE",
     ).respond_with_data(status=status_code)
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     if status_code == 404:
         ctx = pytest.raises(StatusError)
     else:
@@ -234,7 +231,6 @@ async def test_copy_artifact(
     ).respond_with_data(
         status=status_code, headers={"Location": "/api/v2.0/artifacts/123"}
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
 
     location = await async_client.copy_artifact(
         "testproj",
@@ -261,7 +257,7 @@ async def test_get_artifacts_mock(
         json_from_list(artifacts),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_artifacts(
         "testproj",
         "testrepo",
@@ -289,7 +285,7 @@ async def test_add_artifact_label_mock(
         method="POST",
         json=label.model_dump(exclude_unset=True),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.add_artifact_label(
         "testproj",
         "testrepo",
@@ -313,7 +309,7 @@ async def test_get_artifact_mock(
         artifact.model_dump_json(),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     # TODO: test params
     resp = await async_client.get_artifact(
         "testproj",
@@ -338,7 +334,6 @@ async def test_delete_artifact_mock(
         status=status_code,
     )
 
-    async_client.url = httpserver.url_for("/api/v2.0")
     if status_code == 404:
         ctx = pytest.raises(StatusError)
     else:
@@ -361,7 +356,6 @@ async def test_delete_artifact_label_mock(
         status=status_code,
     )
 
-    async_client.url = httpserver.url_for("/api/v2.0")
     if status_code == 404:
         ctx = pytest.raises(StatusError)
     else:

--- a/tests/endpoints/test_audit.py
+++ b/tests/endpoints/test_audit.py
@@ -30,7 +30,6 @@ async def test_get_audit_logs_mock(
         json_from_list(audit_logs),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
 
     logs = await async_client.get_audit_logs()
     assert logs == audit_logs

--- a/tests/endpoints/test_configure.py
+++ b/tests/endpoints/test_configure.py
@@ -24,7 +24,7 @@ async def test_get_config_mock(
         "/api/v2.0/configurations",
         method="GET",
     ).respond_with_json(config.model_dump(mode="json"))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_config()
     assert resp == config
 
@@ -42,5 +42,5 @@ async def test_update_config_mock(
         method="PUT",
         json=config.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_config(config)

--- a/tests/endpoints/test_cveallowlist.py
+++ b/tests/endpoints/test_cveallowlist.py
@@ -25,7 +25,7 @@ async def test_get_cve_allowlist(
         "/api/v2.0/system/CVEAllowlist",
         method="GET",
     ).respond_with_json(cve_allowlist.model_dump(mode="json"))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     allowlist = await async_client.get_cve_allowlist()
     assert allowlist == cve_allowlist
     if allowlist.items:
@@ -46,5 +46,5 @@ async def test_update_cve_allowlist(
         "/api/v2.0/system/CVEAllowlist",
         method="PUT",
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_cve_allowlist(cve_allowlist)

--- a/tests/endpoints/test_gc.py
+++ b/tests/endpoints/test_gc.py
@@ -25,7 +25,6 @@ async def test_get_gc_schedule_mock(
     httpserver: HTTPServer,
     schedule: Schedule,
 ):
-    async_client.url = httpserver.url_for("/api/v2.0")
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/gc/schedule",
         method="GET",
@@ -43,7 +42,7 @@ async def test_create_gc_schedule_mock(
     schedule: Schedule,
 ):
     expect_location = "/api/v2.0/system/gc/schedule"  # idk?
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/gc/schedule",
         method="POST",
@@ -64,7 +63,6 @@ async def test_update_gc_schedule_mock(
     httpserver: HTTPServer,
     schedule: Schedule,
 ):
-    async_client.url = httpserver.url_for("/api/v2.0")
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/gc/schedule",
         method="PUT",
@@ -88,7 +86,7 @@ async def test_get_gc_jobs_mock(
         json_from_list(jobs),
         content_type="application/json",
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_gc_jobs()
     assert resp == jobs
 
@@ -109,7 +107,7 @@ async def test_get_gc_job_mock(
         job.model_dump_json(),
         content_type="application/json",
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_gc_job(123)
     assert resp == job
 
@@ -131,7 +129,7 @@ async def test_get_gc_log_mock(
         log,
         content_type="text/plain",
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_gc_log(123, as_list=as_list)
     if as_list:
         assert isinstance(resp, list)

--- a/tests/endpoints/test_health.py
+++ b/tests/endpoints/test_health.py
@@ -23,7 +23,7 @@ async def test_health_check(
     httpserver.expect_oneshot_request(
         "/api/v2.0/health", method="GET"
     ).respond_with_json(healthstatus.model_dump(mode="json"))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     health = await async_client.health_check()
     assert health == healthstatus
     if health.components:  # TODO: add OverallHealthStatus.components strategy

--- a/tests/endpoints/test_icon.py
+++ b/tests/endpoints/test_icon.py
@@ -22,7 +22,7 @@ async def test_get_icon_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/icons/digest", method="GET"
     ).respond_with_data(icon.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_icon("digest")
     assert resp.content_type == icon.content_type
     assert resp.content == icon.content

--- a/tests/endpoints/test_immutable.py
+++ b/tests/endpoints/test_immutable.py
@@ -64,7 +64,7 @@ async def test_update_project_immutable_tag_rule_mock(
         json=rule.model_dump(mode="json", exclude_unset=True),
         headers={"X-Is-Resource-Name": "false"},
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_project_immutable_tag_rule(1234, 1, rule)
 
 
@@ -85,7 +85,7 @@ async def test_enable_project_immutable_tagrule(
         json={"disabled": not enable},
         headers={"X-Is-Resource-Name": "false"},
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.enable_project_immutable_tagrule(1234, 1, enable)
 
 
@@ -99,5 +99,5 @@ async def test_delete_project_immutable_tag_rule_mock(
         method="DELETE",
         headers={"X-Is-Resource-Name": "false"},
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.delete_project_immutable_tag_rule(1234, 1)

--- a/tests/endpoints/test_labels.py
+++ b/tests/endpoints/test_labels.py
@@ -29,7 +29,7 @@ async def test_get_label_mock(
     ).respond_with_data(
         label.model_dump_json(), headers={"Content-Type": "application/json"}
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_label(123)
     assert resp == label
 
@@ -48,7 +48,7 @@ async def test_update_label_mock(
         method="PUT",
         json=label.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_label(123, label)
 
 
@@ -67,7 +67,7 @@ async def test_create_label_mock(
         method="POST",
         json=label.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data(headers={"Location": expect_location})
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.create_label(label)
     assert resp == expect_location
 
@@ -81,7 +81,7 @@ async def test_delete_label_mock(
     httpserver.expect_oneshot_request(
         f"/api/v2.0/labels/{label_id}", method="DELETE"
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.delete_label(label_id)
 
 
@@ -99,7 +99,7 @@ async def test_get_labels_mock(
         json_from_list(labels),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     # TODO: query parameters
     resp = await async_client.get_labels()
     assert resp == labels

--- a/tests/endpoints/test_ldap.py
+++ b/tests/endpoints/test_ldap.py
@@ -33,7 +33,7 @@ async def test_ping_ldap_with_config_mock(
         method="POST",
         json=config.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data(result.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.ping_ldap(config)
     assert resp == result
 
@@ -50,7 +50,7 @@ async def test_ping_ldap_no_config_mock(
         "/api/v2.0/ldap/ping",
         method="POST",
     ).respond_with_data(result.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.ping_ldap()
     assert resp == result
 
@@ -72,7 +72,6 @@ async def test_search_ldap_groups_mock(
         "/api/v2.0/ldap/groups/search",
         method="GET",
     ).respond_with_data(json_from_list(results), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
 
     if not group_name and not group_dn:
         with pytest.raises(ValueError):
@@ -96,7 +95,6 @@ async def test_search_ldap_users_mock(
         "/api/v2.0/ldap/users/search",
         method="GET",
     ).respond_with_data(json_from_list(results), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
 
     resp = await async_client.search_ldap_users(username)
     assert resp == results
@@ -115,7 +113,7 @@ async def test_import_ldap_users_mock(
         method="POST",
         json={"ldap_uid_list": user_ids},
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     # The method constructs the request model,
     # we just pass in the list of user IDs.
     await async_client.import_ldap_users(user_ids)

--- a/tests/endpoints/test_oidc.py
+++ b/tests/endpoints/test_oidc.py
@@ -29,7 +29,7 @@ async def test_test_oidc_mock(
         method="POST",
         json=oidcreq.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data(status=status)
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     if status == 200:
         ctx = nullcontext()
     else:

--- a/tests/endpoints/test_permissions.py
+++ b/tests/endpoints/test_permissions.py
@@ -26,7 +26,6 @@ async def test_get_permissions(
         permissions.model_dump(mode="json"),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
 
     resp = await async_client.get_permissions()
     assert resp == permissions

--- a/tests/endpoints/test_ping.py
+++ b/tests/endpoints/test_ping.py
@@ -12,6 +12,6 @@ async def test_ping(
     httpserver: HTTPServer,
 ):
     httpserver.expect_oneshot_request("/api/v2.0/ping").respond_with_data("pong")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     pong = await async_client.ping()
     assert pong == "pong"

--- a/tests/endpoints/test_projectmetadata.py
+++ b/tests/endpoints/test_projectmetadata.py
@@ -26,7 +26,7 @@ async def test_get_project_metadata_mock(
     httpserver.expect_oneshot_request(
         f"/api/v2.0/projects/{project_name_or_id}/metadatas", method="GET"
     ).respond_with_data(metadata.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_project_metadata(project_name_or_id)
     assert resp == metadata
 
@@ -45,7 +45,7 @@ async def test_set_project_metadata_mock(
         method="POST",
         json=metadata.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.set_project_metadata(project_name_or_id, metadata)
 
 
@@ -58,7 +58,7 @@ async def test_get_project_metadata_entry_mock(
     httpserver.expect_oneshot_request(
         f"/api/v2.0/projects/{project_name_or_id}/metadatas/auto_scan", method="GET"
     ).respond_with_json({"auto_scan": "true"})
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_project_metadata_entry(
         project_name_or_id, "auto_scan"
     )
@@ -78,7 +78,7 @@ async def test_update_project_metadata_entry_mock(
     httpserver.expect_oneshot_request(
         f"/api/v2.0/projects/{project_name_or_id}/metadatas/auto_scan", method="PUT"
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_project_metadata_entry(
         project_name_or_id,
         "auto_scan",
@@ -97,7 +97,7 @@ async def test_update_project_metadata_with_extra_field_mock(
     httpserver.expect_oneshot_request(
         f"/api/v2.0/projects/{project_name_or_id}/metadatas/foo", method="PUT"
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_project_metadata_entry(
         project_name_or_id,
         "foo",
@@ -114,5 +114,5 @@ async def test_delete_project_metadata_entry_mock(
     httpserver.expect_oneshot_request(
         f"/api/v2.0/projects/{project_name_or_id}/metadatas/foo", method="DELETE"
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.delete_project_metadata_entry(project_name_or_id, "foo")

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -34,7 +34,7 @@ async def test_set_project_scanner_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/projects/1234/scanner", method="PUT"
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.set_project_scanner("1234", "myscanner")
 
 
@@ -50,7 +50,7 @@ async def test_get_project_scanner_mock(
         "/api/v2.0/projects/1234/scanner",
         method="GET",
     ).respond_with_data(scanner.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_project_scanner("1234")
     assert resp.model_dump() == scanner.model_dump()
 
@@ -66,7 +66,7 @@ async def test_get_project_logs_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/projects/1234/logs", method="GET"
     ).respond_with_data(json_from_list(logs), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_project_logs("1234")
     assert resp == logs
 
@@ -82,7 +82,7 @@ async def test_project_exists_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/projects", method="HEAD", query_string="project_name=1234"
     ).respond_with_data(status=status)
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     try:
         assert await async_client.project_exists("1234") == expected
     except Exception as e:
@@ -103,7 +103,7 @@ async def test_create_project_mock(
         method="POST",
         json=project.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data(headers={"Location": "%2Fapi%2Fv2.0%2Fprojects%2F1234"})
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.create_project(project)
     assert resp == "/api/v2.0/projects/1234"
 
@@ -120,7 +120,7 @@ async def test_get_projects_mock(
         "/api/v2.0/projects",
         method="GET",
     ).respond_with_data(json_from_list(projects), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_projects("1234")
     assert resp == projects
 
@@ -137,7 +137,7 @@ async def test_update_project_mock(
         "/api/v2.0/projects/1234",
         method="PUT",
     ).respond_with_data(project.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_project("1234", project)
 
 
@@ -153,7 +153,7 @@ async def test_get_project_mock(
         "/api/v2.0/projects/1234",
         method="GET",
     ).respond_with_data(project.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_project("1234")
     assert resp == project
 
@@ -167,7 +167,7 @@ async def test_delete_project_mock(
         "/api/v2.0/projects/1234",
         method="DELETE",
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.delete_project("1234")
 
 
@@ -183,7 +183,7 @@ async def test_get_project_scanner_candidates_mock(
         "/api/v2.0/projects/1234/scanner/candidates",
         method="GET",
     ).respond_with_data(json_from_list(scanners), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_project_scanner_candidates("1234")
     assert [r.model_dump() for r in resp] == [s.model_dump() for s in scanners]
 
@@ -202,7 +202,7 @@ async def test_get_project_summary_mock(
     ).respond_with_data(
         project_summary.model_dump_json(), content_type="application/json"
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_project_summary("1234")
     assert resp == project_summary
 
@@ -219,7 +219,7 @@ async def test_get_project_deletable_mock(
         "/api/v2.0/projects/1234/_deletable",
         method="GET",
     ).respond_with_data(deletable.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_project_deletable("1234")
     assert resp == deletable
 
@@ -236,7 +236,7 @@ async def test_get_project_member_mock(
         "/api/v2.0/projects/1234/members/567",
         method="GET",
     ).respond_with_data(member.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_project_member("1234", 567)
     assert resp == member
 
@@ -254,7 +254,7 @@ async def test_add_project_member_mock_fuzz(
         "/api/v2.0/projects/1234/members",
         method="POST",
     ).respond_with_data(status=201)  # TODO: header location
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.add_project_member("1234", member)
 
 
@@ -277,7 +277,7 @@ async def test_add_project_member_with_user_mock(
     ).respond_with_data(
         status=201, headers={"Location": "/api/v2.0/projects/1234/members/567"}
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.add_project_member("1234", member)
 
 
@@ -300,7 +300,7 @@ async def test_add_project_member_with_group_mock(
     ).respond_with_data(
         status=201, headers={"Location": "/api/v2.0/projects/1234/members/567"}
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.add_project_member("1234", member)
 
 
@@ -326,7 +326,7 @@ async def test_add_project_member_user_mock(
     ).respond_with_data(
         status=201, headers={"Location": "/api/v2.0/projects/1234/members/567"}
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.add_project_member_user(
         "1234",
         username_or_id=username or user_id,  # type: ignore
@@ -356,7 +356,7 @@ async def test_add_project_member_group_mock(
     ).respond_with_data(
         status=201, headers={"Location": "/api/v2.0/projects/1234/members/567"}
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.add_project_member_group(
         "1234",
         ldap_group_dn_or_id=ldap_group_dn or group_id,  # type: ignore
@@ -381,7 +381,7 @@ async def test_update_project_member_role_mock(
         method="PUT",
         json=expect.model_dump(exclude_unset=True),
     ).respond_with_data(status=200)
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_project_member_role("1234", 567, role_arg)
 
 
@@ -393,7 +393,7 @@ async def test_remove_project_member_mock(
         "/api/v2.0/projects/1234/members/567",
         method="DELETE",
     ).respond_with_data(status=200)
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.remove_project_member("1234", 567)
 
 
@@ -409,7 +409,7 @@ async def test_get_project_members_mock(
         "/api/v2.0/projects/1234/members",
         method="GET",
     ).respond_with_data(json_from_list(members), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_project_members("1234")
     assert resp == members
 

--- a/tests/endpoints/test_purge.py
+++ b/tests/endpoints/test_purge.py
@@ -27,7 +27,7 @@ async def test_get_audit_log_rotation_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/purgeaudit/1234", method="GET"
     ).respond_with_data(status.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_audit_log_rotation("1234")
     assert resp == status
 
@@ -40,7 +40,7 @@ async def test_get_audit_log_rotation_log_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/purgeaudit/1234/log", method="GET"
     ).respond_with_data("Hello World")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_audit_log_rotation_log(1234)
     assert resp == "Hello World"
 
@@ -56,7 +56,7 @@ async def test_update_audit_log_rotation_schedule_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/purgeaudit/schedule", method="PUT"
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_audit_log_rotation_schedule(schedule)
 
 
@@ -69,7 +69,7 @@ async def test_stop_audit_log_rotation_mock(
         "/api/v2.0/system/purgeaudit/1234",
         method="PUT",
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.stop_audit_log_rotation(1234)
 
 
@@ -84,7 +84,7 @@ async def test_create_audit_log_rotation_schedule_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/purgeaudit/schedule", method="POST"
     ).respond_with_data(headers={"Location": "1234"})
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.create_audit_log_rotation_schedule(schedule)
     assert resp == "1234"
 
@@ -100,7 +100,7 @@ async def test_get_audit_log_rotation_schedule_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/purgeaudit/schedule", method="GET"
     ).respond_with_data(schedule.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_audit_log_rotation_schedule()
     assert resp == schedule
 
@@ -114,7 +114,7 @@ async def test_get_audit_log_rotation_schedule_none(
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/purgeaudit/schedule", method="GET"
     ).respond_with_data("", content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_audit_log_rotation_schedule()
     assert resp == ExecHistory()  # expect empty ExecHistory object
 
@@ -133,6 +133,6 @@ async def test_get_audit_log_rotation_history_mock(
         json_from_list(logs),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_audit_log_rotation_history()
     assert resp == logs

--- a/tests/endpoints/test_quota.py
+++ b/tests/endpoints/test_quota.py
@@ -26,7 +26,7 @@ async def test_get_quotas_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/quotas", method="GET"
     ).respond_with_json([q.model_dump(mode="json", exclude_unset=True) for q in quotas])
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_quotas()
     if quotas:
         assert resp == quotas
@@ -39,7 +39,7 @@ async def test_update_quota(async_client: HarborAsyncClient, httpserver: HTTPSer
         method="PUT",
         json={"hard": {"storage": 100, "storage2": 200}},
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_quota(
         1234,
         QuotaUpdateReq(
@@ -62,6 +62,6 @@ async def test_get_quota_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/quotas/1234", method="GET"
     ).respond_with_json(quota.model_dump(mode="json", exclude_unset=True))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_quota(1234)
     assert resp == quota

--- a/tests/endpoints/test_registries.py
+++ b/tests/endpoints/test_registries.py
@@ -32,7 +32,7 @@ async def test_check_registry_status_mock(
         method="POST",
         json=ping.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.check_registry_status(ping)
 
 
@@ -48,7 +48,7 @@ async def test_get_registry_adapters_mock(
         "/api/v2.0/replication/adapters",
         method="GET",
     ).respond_with_json(adapters)
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.get_registry_adapters()
 
 
@@ -63,7 +63,7 @@ async def test_get_registry_info_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/registries/123/info", method="GET"
     ).respond_with_json(registryinfo.model_dump(mode="json", exclude_unset=True))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.get_registry_info(123)
 
 
@@ -81,7 +81,7 @@ async def test_get_registry_providers_mock(
         providers.model_dump_json(),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_registry_providers()
     assert resp == providers
 
@@ -99,7 +99,7 @@ async def test_update_registry_mock(
         method="PUT",
         json=registry.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_registry(123, registry)
 
 
@@ -114,7 +114,7 @@ async def test_get_registry_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/registries/123", method="GET"
     ).respond_with_json(registry.model_dump(mode="json", exclude_unset=True))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_registry(123)
     assert resp == registry
 
@@ -127,7 +127,7 @@ async def test_delete_registry_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/registries/123", method="DELETE"
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     # TODO test missing_ok=True
     await async_client.delete_registry(123)
 
@@ -145,7 +145,7 @@ async def test_create_registry_mock(
         method="POST",
         json=registry.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data(headers={"Location": "/api/v2.0/registries/123"})
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.create_registry(registry)
     assert resp == "/api/v2.0/registries/123"
 
@@ -161,6 +161,6 @@ async def test_get_registries_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/registries", method="GET"
     ).respond_with_data(json_from_list(registries), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_registries()
     assert resp == registries

--- a/tests/endpoints/test_replication.py
+++ b/tests/endpoints/test_replication.py
@@ -28,7 +28,7 @@ async def test_get_replication_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/replication/executions/1234", method="GET"
     ).respond_with_data(replication.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_replication(1234)
     assert resp == replication
 
@@ -46,7 +46,7 @@ async def test_start_replication_mock(
     ).respond_with_data(
         headers={"Location": "http://localhost/api/v2.0/replication/executions/1234"}
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.start_replication(1234)
     assert resp == "http://localhost/api/v2.0/replication/executions/1234"
 
@@ -59,7 +59,7 @@ async def test_stop_replication(
     httpserver.expect_oneshot_request(
         "/api/v2.0/replication/executions/1234", method="PUT"
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.stop_replication(1234)
 
 
@@ -77,7 +77,7 @@ async def test_get_replications_mock(
         json_from_list(replications),
         content_type="application/json",
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_replications()
     assert resp == replications
 
@@ -96,7 +96,7 @@ async def test_get_replication_tasks_mock(
         json_from_list(replications),
         content_type="application/json",
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_replication_tasks(1234)
     assert resp == replications
 
@@ -112,7 +112,7 @@ async def test_get_replication_task_log(
         "logline1\nlogline2",
         content_type="text/plain",
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_replication_task_log(1234, 567)
     assert resp == "logline1\nlogline2"
 
@@ -131,7 +131,7 @@ async def test_get_replication_policy(
         policy.model_dump_json(),
         content_type="application/json",
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_replication_policy(1234)
     assert resp == policy
 
@@ -154,7 +154,7 @@ async def test_create_replication_policy(
         },
         status=201,
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.create_replication_policy(policy)
     assert resp == "http://localhost:8080/api/v2.0/replication/policies/1234"
 
@@ -172,7 +172,7 @@ async def test_update_replication_policy(
         method="PUT",
         json=policy.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_replication_policy(1234, policy)
 
 
@@ -185,7 +185,7 @@ async def test_delete_replication_policy(
         "/api/v2.0/replication/policies/1234",
         method="DELETE",
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.delete_replication_policy(1234)
 
 
@@ -203,6 +203,6 @@ async def test_get_replication_policies(
         json_from_list(policies),
         content_type="application/json",
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_replication_policies()
     assert resp == policies

--- a/tests/endpoints/test_repositories.py
+++ b/tests/endpoints/test_repositories.py
@@ -29,7 +29,7 @@ async def test_get_repository_mock(
     ).respond_with_data(
         repository.model_dump_json(), headers={"Content-Type": "application/json"}
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_repository("testproj", "testrepo")
     assert resp == repository
 
@@ -47,7 +47,7 @@ async def test_update_repository_mock(
         method="PUT",
         json=repository.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_repository(
         "testproj",
         "testrepo",
@@ -63,7 +63,7 @@ async def test_delete_repository_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/projects/testproj/repositories/testrepo", method="DELETE"
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.delete_repository("testproj", "testrepo")
 
 
@@ -88,6 +88,6 @@ async def test_get_repositories_mock(
         json_from_list(repositories),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_repositories(project_name)
     assert resp == repositories

--- a/tests/endpoints/test_retention.py
+++ b/tests/endpoints/test_retention.py
@@ -41,7 +41,7 @@ async def test_get_project_retention_id_mock(
         method="GET",
         headers={"X-Is-Resource-Name": "false" if is_id else "true"},
     ).respond_with_data(project.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_project_retention_id(project_name_or_id)
     assert resp == expect_id
 
@@ -61,7 +61,7 @@ async def test_get_project_retention_id_no_retention_id_mock(
         f"/api/v2.0/projects/{project_name_or_id}",
         method="GET",
     ).respond_with_json(project.model_dump(mode="json"))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     with pytest.raises(NotFound) as exc_info:
         await async_client.get_project_retention_id(project_name_or_id)
     assert "retention ID" in exc_info.exconly()
@@ -82,7 +82,7 @@ async def test_get_project_retention_id_invalid_id(
         f"/api/v2.0/projects/{project_name_or_id}",
         method="GET",
     ).respond_with_json(project.model_dump(mode="json"))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     with pytest.raises(HarborAPIException) as exc_info:
         await async_client.get_project_retention_id(project_name_or_id)
     assert "convert" in exc_info.exconly()
@@ -101,7 +101,7 @@ async def test_get_retention_policy_mock(
         f"/api/v2.0/retentions/{retention_id}",
         method="GET",
     ).respond_with_data(policy.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_retention_policy(retention_id)
     assert resp == policy
 
@@ -121,7 +121,7 @@ async def test_create_retention_policy_mock(
     ).respond_with_data(
         headers={"Location": expect_location},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.create_retention_policy(policy)
     assert resp == expect_location
 
@@ -140,7 +140,7 @@ async def test_update_retention_policy_mock(
         method="PUT",
         json=policy.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_retention_policy(policy_id, policy)
 
 
@@ -154,7 +154,7 @@ async def test_delete_retention_policy_mock(
         f"/api/v2.0/retentions/{policy_id}",
         method="DELETE",
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.delete_retention_policy(policy_id)
 
 
@@ -176,7 +176,7 @@ async def test_get_retention_tasks_mock(
         json_from_list(tasks),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_retention_tasks(
         policy_id, execution_id, page=1, page_size=10
     )
@@ -198,7 +198,7 @@ async def test_get_retention_metadata_mock(
         metadata.model_dump_json(),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_retention_metadata()
     assert resp == metadata
 
@@ -218,7 +218,7 @@ async def test_get_retention_execution_task_log_mock(
         f"/api/v2.0/retentions/{retention_id}/executions/{execution_id}/tasks/{task_id}",
         method="GET",
     ).respond_with_data(log, content_type="text/plain")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_retention_execution_task_log(
         retention_id, execution_id, task_id
     )
@@ -242,7 +242,7 @@ async def test_get_retention_executions_mock(
         json_from_list(executions),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_retention_executions(
         retention_id, page=1, page_size=10
     )
@@ -263,7 +263,7 @@ async def test_start_retention_execution_mock(
     ).respond_with_data(
         headers={"Location": expect_location},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.start_retention_execution(retention_id, dry_run=dry_run)
     assert resp == expect_location
 
@@ -279,5 +279,5 @@ async def test_stop_retention_execution_mock(
         method="PATCH",
         json={"action": "stop"},
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.stop_retention_execution(retention_id, execution_id)

--- a/tests/endpoints/test_robots.py
+++ b/tests/endpoints/test_robots.py
@@ -38,7 +38,7 @@ async def test_create_robot_mock(
     ).respond_with_data(
         robot_created.model_dump_json(), content_type="application/json"
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.create_robot(robot)
     assert resp == robot_created
 
@@ -56,7 +56,7 @@ async def test_create_robot_empty_response_mock(
         method="POST",
         json=robot.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data("{}", content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     with pytest.raises(HarborAPIException) as exc_info:
         await async_client.create_robot(robot)
     assert "empty response" in exc_info.value.args[0].lower()
@@ -83,7 +83,6 @@ async def test_create_robot_with_path_mock(
     ).respond_with_data(
         robot_created.model_dump_json(), content_type="application/json"
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
 
     filename = f"{robot_created.name or robot.name}.json"
     filepath = tmp_path / filename
@@ -119,7 +118,7 @@ async def test_get_robots_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/robots", method="GET"
     ).respond_with_data(json_from_list(robots), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_robots()
     assert resp == robots
 
@@ -135,7 +134,7 @@ async def test_get_robot_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/robots/1234", method="GET"
     ).respond_with_data(robot.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_robot(1234)
     assert resp == robot
 
@@ -153,7 +152,7 @@ async def test_update_robot_mock(
         method="PUT",
         json=robot.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_robot(1234, robot)
 
 
@@ -165,7 +164,7 @@ async def test_delete_robot_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/robots/1234", method="DELETE"
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.delete_robot(1234)
 
 
@@ -185,6 +184,6 @@ async def test_refresh_robot_secret_mock(
     ).respond_with_data(
         expected_resp.model_dump_json(), content_type="application/json"
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.refresh_robot_secret(1234, secret)
     assert resp == expected_resp

--- a/tests/endpoints/test_scan.py
+++ b/tests/endpoints/test_scan.py
@@ -26,7 +26,7 @@ async def test_scan_artifact_mock(
         endpoint_path,
         method="POST",
     ).respond_with_data("foo", status=status_code)
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.scan_artifact(project, repository, artifact)
     if status_code == 200:
         assert "expected 202" in caplog.text
@@ -49,7 +49,6 @@ async def test_get_scan_report_log_mock(
         method="GET",
     ).respond_with_data(f"foo: {report_id}")
 
-    async_client.url = httpserver.url_for("/api/v2.0")
     resp = await async_client.get_artifact_scan_report_log(
         project, repository, artifact, report_id
     )
@@ -75,7 +74,7 @@ async def test_stop_artifact_scan_mock(
         endpoint_path,
         method="POST",
     ).respond_with_data("foo", status=status_code)
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.stop_artifact_scan(project, repository, artifact)
     if status_code == 200:
         assert "expected 202" in caplog.text

--- a/tests/endpoints/test_scanall.py
+++ b/tests/endpoints/test_scanall.py
@@ -23,7 +23,7 @@ async def test_get_scan_all_metrics_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/scans/all/metrics", method="GET"
     ).respond_with_json(stats.model_dump(mode="json", exclude_unset=True))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     metrics = await async_client.get_scan_all_metrics()
     assert metrics is not None
 
@@ -40,7 +40,7 @@ async def test_update_scan_all_schedule_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/scanAll/schedule", method="PUT"
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_scan_all_schedule(
         schedule
     )  # just test endpoint is working
@@ -60,7 +60,7 @@ async def test_create_scan_all_schedule_mock(
     ).respond_with_data(
         status=201, headers={"Location": "/system/scanAll/schedules/1234"}
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.create_scan_all_schedule(schedule)
     assert resp == "/system/scanAll/schedules/1234"
 
@@ -77,7 +77,7 @@ async def test_get_scan_all_schedule(
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/scanAll/schedule", method="GET"
     ).respond_with_json(schedule.model_dump(mode="json", exclude_unset=True))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     schedule_resp = await async_client.get_scan_all_schedule()
     assert schedule_resp == schedule
 
@@ -89,5 +89,5 @@ async def test_stop_scan_all_job(
     httpserver.expect_oneshot_request(
         "/api/v2.0/system/scanAll/stop", method="POST"
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.stop_scan_all_job()

--- a/tests/endpoints/test_scanexport.py
+++ b/tests/endpoints/test_scanexport.py
@@ -30,7 +30,7 @@ async def test_get_scan_exports_mock(
         exports.model_dump_json(),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_scan_exports()
     assert resp == exports
 
@@ -51,7 +51,7 @@ async def test_get_scan_export_mock(
         execution.model_dump_json(),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_scan_export(execution_id)
     assert resp == execution
 
@@ -72,7 +72,7 @@ async def test_export_scan_data_mock(
         headers={"X-Scan-Data-Type": scan_type},
         data=request.model_dump_json(exclude_unset=True),
     ).respond_with_data(job.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.export_scan_data(request, scan_type)
     assert resp == job
 
@@ -92,7 +92,7 @@ async def test_export_scan_data_empty_response_mock(
         headers={"X-Scan-Data-Type": scan_type},
         data=request.model_dump_json(exclude_unset=True),
     ).respond_with_data("{}", content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     with pytest.raises(HarborAPIException) as exc_info:
         await async_client.export_scan_data(request, scan_type)
     assert "empty response" in exc_info.value.args[0].lower()
@@ -109,7 +109,7 @@ async def test_download_scan_export_mock(
         f"/api/v2.0/export/cve/download/{execution_id}",
         method="GET",
     ).respond_with_data(data)
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.download_scan_export(execution_id)
     assert resp.content == data
     assert bytes(resp) == data

--- a/tests/endpoints/test_scanners.py
+++ b/tests/endpoints/test_scanners.py
@@ -27,7 +27,7 @@ async def test_create_scanner_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/scanners", method="POST"
     ).respond_with_data(status=201, headers={"Location": "/scanners/1234"})
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.create_scanner(scanner)
     assert resp == "/scanners/1234"
 
@@ -45,7 +45,7 @@ async def test_get_scanners_mock(
     httpserver.expect_oneshot_request("/api/v2.0/scanners").respond_with_json(
         [scanner1.model_dump(), scanner2.model_dump()]
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_scanners()
     assert len(resp) == 2
     assert resp[0].model_dump() == scanner1.model_dump()
@@ -63,7 +63,7 @@ async def test_get_scanner_mock(
     httpserver.expect_oneshot_request("/api/v2.0/scanners/1234").respond_with_json(
         scanner.model_dump()
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_scanner(registration_id=1234)
     assert resp.model_dump() == scanner.model_dump()
 
@@ -79,7 +79,7 @@ async def test_get_scanner_metadata_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/scanners/1234/metadata"
     ).respond_with_json(scannermeta.model_dump(mode="json", exclude_unset=True))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_scanner_metadata(registration_id=1234)
     assert resp == scannermeta
 
@@ -95,7 +95,7 @@ async def test_delete_scanner_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/scanners/1234", method="DELETE"
     ).respond_with_data(scanner.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.delete_scanner(1234)
     assert resp.model_dump() == scanner.model_dump()
 
@@ -111,7 +111,7 @@ async def test_delete_scanner_no_response_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/scanners/1234", method="DELETE"
     ).respond_with_data("{}", content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     with pytest.raises(HarborAPIException) as exc_info:
         await async_client.delete_scanner(1234)
     assert "got nothing" in exc_info.value.args[0]
@@ -134,7 +134,7 @@ async def test_set_default_scanner_mock(
             mode="json", exclude_unset=True
         ),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.set_default_scanner(1234, is_default)
 
 
@@ -151,7 +151,7 @@ async def test_ping_scanner_adapter_mock(
         method="POST",
         json=settings.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.ping_scanner_adapter(settings)
 
 
@@ -168,5 +168,5 @@ async def test_update_scanner_mock(
         method="PUT",
         json=scanner.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_scanner(1234, scanner)

--- a/tests/endpoints/test_search.py
+++ b/tests/endpoints/test_search.py
@@ -22,7 +22,7 @@ async def test_search_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/search", method="GET", query_string={"q": "testproj"}
     ).respond_with_data(search.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.search("testproj")
     assert resp == search
 

--- a/tests/endpoints/test_statistic.py
+++ b/tests/endpoints/test_statistic.py
@@ -22,6 +22,6 @@ async def test_get_statistics_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/statistics", method="GET"
     ).respond_with_json(statistic.model_dump(mode="json", exclude_unset=True))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_statistics()
     assert resp == statistic

--- a/tests/endpoints/test_systeminfo.py
+++ b/tests/endpoints/test_systeminfo.py
@@ -23,7 +23,7 @@ async def test_get_system_volume_info_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/systeminfo/volumes", method="GET"
     ).respond_with_json(systeminfo.model_dump(mode="json", exclude_unset=True))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_system_volume_info()
     assert resp == systeminfo
 
@@ -39,7 +39,7 @@ async def test_get_system_info_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/systeminfo", method="GET"
     ).respond_with_json(generalinfo.model_dump(mode="json", exclude_unset=True))
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_system_info()
     assert resp == generalinfo
 
@@ -55,6 +55,6 @@ async def test_get_system_certificate_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/systeminfo/getcert", method="GET"
     ).respond_with_data(content)
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_system_certificate()
     assert resp.content == content

--- a/tests/endpoints/test_usergroups.py
+++ b/tests/endpoints/test_usergroups.py
@@ -24,7 +24,6 @@ async def test_search_usergroups_mock(
     httpserver: HTTPServer,
     usergroups: List[UserGroupSearchItem],
 ):
-    async_client.url = httpserver.url_for("/api/v2.0")
     httpserver.expect_oneshot_request(
         "/api/v2.0/usergroups/search",
         method="GET",
@@ -44,7 +43,7 @@ async def test_create_usergroup_mock(
 ):
     usergroup.id = 123
     expect_location = "/api/v2.0/usergroups/123"  # idk?
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     httpserver.expect_oneshot_request(
         "/api/v2.0/usergroups",
         method="POST",
@@ -65,7 +64,6 @@ async def test_update_usergroup_mock(
     httpserver: HTTPServer,
     usergroup: UserGroup,
 ):
-    async_client.url = httpserver.url_for("/api/v2.0")
     httpserver.expect_oneshot_request(
         "/api/v2.0/usergroups/123",
         method="PUT",
@@ -89,7 +87,7 @@ async def test_get_usergroups_mock(
         json_from_list(usergroups),
         content_type="application/json",
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_usergroups()
     assert resp == usergroups
 
@@ -110,7 +108,7 @@ async def test_get_usergroup_mock(
         usergroup.model_dump_json(),
         content_type="application/json",
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_usergroup(123)
     assert resp == usergroup
 
@@ -124,5 +122,5 @@ async def test_delete_usergroup(
         "/api/v2.0/usergroups/123",
         method="DELETE",
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.delete_usergroup(123)

--- a/tests/endpoints/test_users.py
+++ b/tests/endpoints/test_users.py
@@ -35,7 +35,7 @@ async def test_get_users_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/users", method="GET"
     ).respond_with_json([user1.model_dump(mode="json"), user2.model_dump(mode="json")])
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     users = await async_client.get_users()
     assert len(users) == 2
     assert users[0] == user1
@@ -50,7 +50,7 @@ async def test_set_user_cli_secret_mock(
     httpserver.expect_oneshot_request(
         "/api/v2.0/users/1234/cli_secret", method="PUT", json={"secret": "secret1234"}
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.set_user_cli_secret(1234, "secret1234")
 
 
@@ -65,7 +65,7 @@ async def test_search_users_by_username_mock(
     httpserver.expect_oneshot_request("/api/v2.0/users/search").respond_with_data(
         json_from_list(users), content_type="application/json"
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.search_users_by_username("username")
     assert resp == users
 
@@ -102,7 +102,7 @@ async def test_get_current_user_permissions_mock(
         method="GET",
         query_string=query_string,
     ).respond_with_data(json_from_list(permissions), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_current_user_permissions(scope, relative)
     assert resp == permissions
 
@@ -119,7 +119,7 @@ async def test_get_current_user_mock(
         "/api/v2.0/users/current",
         method="GET",
     ).respond_with_data(user.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_current_user()
     assert resp == user
 
@@ -135,7 +135,7 @@ async def test_set_user_admin_mock(
         "/api/v2.0/users/1234/sysadmin",
         method="PUT",
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.set_user_admin(1234, is_admin)
 
 
@@ -164,7 +164,7 @@ async def test_set_user_password_mock(
             new_password=new_password, old_password=old_password
         ).model_dump(mode="json", exclude_unset=True),
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.set_user_password(1234, new_password, old_password)
 
 
@@ -181,7 +181,7 @@ async def test_create_user_mock(
         method="POST",
         json=user.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data(status=201, headers={"Location": "/api/v2.0/users/1234"})
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.create_user(user)
     assert resp == "/api/v2.0/users/1234"
 
@@ -199,7 +199,7 @@ async def test_update_user_mock(
         method="PUT",
         json=user.model_dump(mode="json", exclude_unset=True),
     ).respond_with_data(status=200)
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_user(1234, user)
 
 
@@ -215,7 +215,7 @@ async def test_get_user_mock(
         "/api/v2.0/users/1234",
         method="GET",
     ).respond_with_data(user.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_user(1234)
     assert user == resp
 
@@ -245,7 +245,6 @@ async def test_get_user_by_username_mock(
         method="GET",
     ).respond_with_data(user.model_dump_json(), content_type="application/json")
 
-    async_client.url = httpserver.url_for("/api/v2.0")
     resp = await async_client.get_user_by_username("test-user")
     assert resp == user
 
@@ -256,7 +255,7 @@ async def test_get_user_by_username_user_not_found_mock(
 ):
     """Try to find user that doesn't exist."""
     httpserver.expect_oneshot_request("/api/v2.0/users/search").respond_with_json([])
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     with pytest.raises(NotFound):
         await async_client.get_user_by_username("test-user")
 
@@ -270,7 +269,7 @@ async def test_get_user_by_username_user_no_id_mock(
     httpserver.expect_oneshot_request("/api/v2.0/users/search").respond_with_json(
         [user.model_dump(mode="json")]
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     with pytest.raises(HarborAPIException) as exc_info:
         await async_client.get_user_by_username("test-user")
     assert "no id" in exc_info.exconly().lower()
@@ -285,5 +284,5 @@ async def test_delete_user_mock(
         "/api/v2.0/users/1234",
         method="DELETE",
     ).respond_with_data()  # API responds with status 200, not 204
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.delete_user(1234)

--- a/tests/endpoints/test_webhooks.py
+++ b/tests/endpoints/test_webhooks.py
@@ -37,7 +37,7 @@ async def test_get_webhook_jobs_mock(
         json_from_list(jobs),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_webhook_jobs(project_id, policy_id)
     assert resp == jobs
 
@@ -59,7 +59,7 @@ async def test_create_webhook_policy_mock(
     ).respond_with_data(
         headers={"Location": "/api/v2.0/projects/123/webhook/policies/456"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.create_webhook_policy(project_id, policy)
     assert resp == expect_location
 
@@ -81,7 +81,7 @@ async def test_get_webhook_policies_mock(
         json_from_list(policies),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_webhook_policies(project_id)
     assert resp == policies
 
@@ -100,7 +100,7 @@ async def test_get_webhook_supported_events_mock(
         method="GET",
         headers={"X-Is-Resource-Name": "false"},
     ).respond_with_data(events.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_webhook_supported_events(project_id)
     assert resp == events
 
@@ -122,7 +122,7 @@ async def test_get_webhook_policy_last_trigger_mock(
         json_from_list(triggers),
         headers={"Content-Type": "application/json"},
     )
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_webhook_policy_last_trigger(project_id)
     assert resp == triggers
 
@@ -142,7 +142,7 @@ async def test_update_webhook_policy_mock(
         method="PUT",
         headers={"X-Is-Resource-Name": "false"},
     ).respond_with_data()
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.update_webhook_policy(project_id, policy_id, policy)
 
 
@@ -161,7 +161,7 @@ async def test_get_webhook_policy_mock(
         method="GET",
         headers={"X-Is-Resource-Name": "false"},
     ).respond_with_data(policy.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     resp = await async_client.get_webhook_policy(project_id, policy_id)
     assert resp == policy
 
@@ -181,5 +181,5 @@ async def test_delete_webhook_policy_mock(
         method="DELETE",
         headers={"X-Is-Resource-Name": "false"},
     ).respond_with_data(policy.model_dump_json(), content_type="application/json")
-    async_client.url = httpserver.url_for("/api/v2.0")
+
     await async_client.delete_webhook_policy(project_id, policy_id)

--- a/tests/test_responselog.py
+++ b/tests/test_responselog.py
@@ -11,7 +11,6 @@ async def test_response_log(async_client: HarborAsyncClient, httpserver: HTTPSer
         [{"username": "user1"}, {"username": "user2"}], status=200
     )
 
-    async_client.url = httpserver.url_for("/api/v2.0")
     await async_client.get_users()
     await async_client.get_users()
     await async_client.get_users()
@@ -51,7 +50,6 @@ async def test_last_response(async_client: HarborAsyncClient, httpserver: HTTPSe
         [{"username": "user1"}, {"username": "user2"}], status=200
     )
 
-    async_client.url = httpserver.url_for("/api/v2.0")
     await async_client.get_users()
     last_response = async_client.last_response
     assert last_response is not None

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -118,7 +118,6 @@ async def test_get_retry_mock(async_client: HarborAsyncClient, httpserver: HTTPS
         [{"username": "user1"}, {"username": "user2"}],
     )
 
-    async_client.url = httpserver.url_for("/api/v2.0")
     users = await async_client.get("/users")
     assert isinstance(users, list)
     assert len(users) == 2
@@ -136,7 +135,6 @@ async def test_get_retry_disabled_mock(
         [{"username": "user1"}, {"username": "user2"}],
     )
 
-    async_client.url = httpserver.url_for("/api/v2.0")
     async_client.retry = None  # disable retry
     with pytest.raises(ConnectError):
         users = await async_client.get("/users")
@@ -170,7 +168,6 @@ async def test_get_retry_custom_wait_gen(
             call_count += 1
             yield 0.01
 
-    async_client.url = httpserver.url_for("/api/v2.0")
     async_client.retry.wait_gen = wait_gen
 
     # First call(s) should fail
@@ -195,8 +192,6 @@ async def test_no_retry_ctx_manager(
     httpserver.expect_oneshot_request("/api/v2.0/users").respond_with_json(
         [{"username": "user1"}, {"username": "user2"}],
     )
-
-    async_client.url = httpserver.url_for("/api/v2.0")
 
     # assert we have active retry settings
     assert async_client.retry is not None


### PR DESCRIPTION
This PR removes the redundant assignment of test server URL in tests. We already assign the URL in the `async_client` fixture.