### PR TITLE
Add `get_artifact_vulnerability_reports`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,17 @@ While the project is still on major version 0, breaking changes may be introduce
   - `HarborAsyncClient.update_project_immutable_tag_rule()`
   - `HarborAsyncClient.enable_project_immutable_tagrule()`
   - `HarborAsyncClient.delete_project_immutable_tag_rule()`
+- Artifact vulnerability reports method:
+  - `HarborAsyncClient.get_artifact_vulnerability_reports()`
 
 ### Removed
 
 - References to Helm charts in `HarborAsyncClient.search()`.
+
+### Deprecated
+
+- `HarborAsyncClient.get_artifact_vulnerabilities()` in favor of `HarborAsyncClient.get_artifact_vulnerability_reports()`.
+  - The old method only supported a single MIME type and was not flexible enough to support returning multiple reports given multiple MIME types. The new method supports this use case and is less strict than the old method in terms of MIME type validation.
 
 ## [0.24.2](https://github.com/unioslo/harborapi/tree/harborapi-v0.24.2) - 2024-06-15
 

--- a/docs/endpoints/artifacts.md
+++ b/docs/endpoints/artifacts.md
@@ -6,7 +6,7 @@
         - get_artifact
         - copy_artifact
         - delete_artifact
-        - get_artifact_vulnerabilities
+        - get_artifact_vulnerability_reports
         - get_artifact_build_history
         - get_artifact_accessories
         - get_artifact_tags
@@ -15,3 +15,4 @@
         - add_artifact_label
         - delete_artifact_label
         - get_artifacts
+        - get_artifact_vulnerabilities

--- a/docs/recipes/artifacts/get-artifact-vulnerabilities.md
+++ b/docs/recipes/artifacts/get-artifact-vulnerabilities.md
@@ -1,6 +1,10 @@
 # Get artifact vulnerability report
 
-We can fetch the vulnerability report for an artifact using [`get_artifact_vulnerabilities`][harborapi.client.HarborAsyncClient.get_artifact_vulnerabilities]. It returns a [`HarborVulnerabilityReport`][harborapi.models.HarborVulnerabilityReport] object. The vulnerability report contains all the vulnerabilities found in the artifact.
+We can fetch the vulnerability report for an artifact using [`get_artifact_vulnerability_reports`][harborapi.client.HarborAsyncClient.get_artifact_vulnerability_reports]. It returns a dict of [`HarborVulnerabilityReport`][harborapi.models.HarborVulnerabilityReport] objects indexed by MIME type. If no reports are found, the dict will be empty.
+
+A [`HarborVulnerabilityReport`][harborapi.models.HarborVulnerabilityReport] is more comprehensive than the [`NativeReportSummary`][harborapi.models.models.NativeReportSummary] returned by [`get_artifact(..., with_scan_overview=True)`](../get-artifact-scan-overview). It contains detailed information about the vulnerabilities found in the artifact.
+
+## Example
 
 ```py
 import asyncio
@@ -15,12 +19,14 @@ async def main() -> None:
         "hello-world",
         "latest",
     )
-    for vulnerability in report.vulnerabilities:
-        print(
-            vulnerability.id,
-            vulnerability.severity,
-            vulnerability.package,
-        )
+    for mime_type, report in reports.items():
+        print(mime_type)
+        for vulnerability in report.vulnerabilities:
+            print(
+                vulnerability.id,
+                vulnerability.severity,
+                vulnerability.package,
+            )
 
 asyncio.run(main())
 ```
@@ -33,7 +39,6 @@ for vulnerability in report.critical:
 ```
 
 Similarly, we can also get [low][harborapi.models.HarborVulnerabilityReport.low], [medium][harborapi.models.HarborVulnerabilityReport.medium], and [high][harborapi.models.HarborVulnerabilityReport.high] severity vulnerabilities, as well as [fixable][harborapi.models.HarborVulnerabilityReport.fixable] and [unfixable][harborapi.models.HarborVulnerabilityReport.unfixable] vulnerabilities:
-
 
 ```py
 for vulnerability in report.low:...
@@ -58,4 +63,39 @@ for vulnerability in report.vulnerabilities:
     if vulnerability.links:
         for link in vulnerability.links:
             print("\t", link)
+```
+
+## The `mime_type` parameter
+
+We can pass in a list of MIME types or a single MIME type to the `mime_type` parameter. The returned dict will only contain the vulnerability reports for the specified MIME types.
+
+```py
+reports = await client.get_artifact_vulnerabilities(
+    ...,
+    mime_type=[
+        "application/vnd.security.vulnerability.report; version=1.1",
+        "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0",
+    ],
+)
+for report in reports:
+    print(report)
+
+# OR
+
+reports = await client.get_artifact_vulnerabilities(
+    ...,
+    mime_type="application/vnd.security.vulnerability.report; version=1.1",
+)
+reports.get("application/vnd.security.vulnerability.report; version=1.1")
+```
+
+Remember, the Artifact might not have a vulnerability report for the specified MIME type. In that case, the dict will be empty.
+
+```py
+reports = await client.get_artifact_vulnerabilities(
+    ...,
+    mime_type=["Lots", "Of", "Mime", "Types"],
+)
+if not reports:
+    print("No vulnerability reports found for the specified MIME types.")
 ```


### PR DESCRIPTION
This PR adds a new method `get_artifact_vulnerability_reports`, which deprecates `get_artifact_vulnerabilities`. The old method was not flexible enough to add support for multiple MIME types without adding a lot of complexity. 

The new method always returns a list of MIME types to vulnerability reports, and no longer raises an exception when a MIME type is not found.