### PR TITLE
Add `get_project_artifacts()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ While the project is still on major version 0, breaking changes may be introduce
 
 ## Unreleased
 
+### Added
+
+- Project artifacts method: `HarborAsyncClient.get_project_artifacts()`
+- `with_sbom_overview` parameter for `HarborAsyncClient.get_artifact()` and `HarborAsyncClient.get_artifacts()` to include SBOM overview in the response.
+
 ### Changed
 
 - Models updated to API schema from [c97253f](https://github.com/goharbor/harbor/blob/4a12623459a754ff4d07fbd1cddb4df436e8524c/api/v2.0/swagger.yaml)

--- a/harborapi/utils.py
+++ b/harborapi/utils.py
@@ -5,6 +5,7 @@ from base64 import b64encode
 from json import JSONDecodeError
 from typing import Dict
 from typing import Optional
+from typing import Sequence
 from typing import Union
 from typing import cast
 from urllib.parse import quote_plus
@@ -253,6 +254,16 @@ def get_project_headers(project_name_or_id: Union[str, int]) -> Dict[str, str]:
         The headers to use for the request.
     """
     return {"X-Is-Resource-Name": str(isinstance(project_name_or_id, str)).lower()}
+
+
+def get_mime_type_header(mime_type: Union[str, Sequence[str]]) -> Dict[str, str]:
+    # NOTE: in the offical API spec, a comma AND space is used to separate:
+    # https://github.com/goharbor/harbor/blob/df4ab856c7597e6fe28b466ba8419257de8a1af7/api/v2.0/swagger.yaml#L6256
+    if not isinstance(mime_type, str):
+        mime_type_param = ", ".join(mime_type)
+    else:
+        mime_type_param = mime_type
+    return {"X-Accept-Vulnerabilities": mime_type_param}
 
 
 def get_params(**kwargs: QueryParamValue) -> QueryParamMapping:

--- a/tests/endpoints/test_projects.py
+++ b/tests/endpoints/test_projects.py
@@ -11,6 +11,7 @@ from hypothesis import strategies as st
 from pytest_httpserver import HTTPServer
 
 from harborapi.client import HarborAsyncClient
+from harborapi.models.models import Artifact
 from harborapi.models.models import AuditLog
 from harborapi.models.models import Project
 from harborapi.models.models import ProjectDeletable
@@ -205,6 +206,23 @@ async def test_get_project_summary_mock(
 
     resp = await async_client.get_project_summary("1234")
     assert resp == project_summary
+
+
+@pytest.mark.asyncio
+@given(st.lists(st.builds(Artifact)))
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+async def test_get_project_artifacts_mock(
+    async_client: HarborAsyncClient,
+    httpserver: HTTPServer,
+    artifacts: List[Artifact],
+):
+    httpserver.expect_oneshot_request(
+        "/api/v2.0/projects/1234/artifacts",
+        method="GET",
+    ).respond_with_data(json_from_list(artifacts), content_type="application/json")
+
+    resp = await async_client.get_project_artifacts("1234")
+    assert resp == artifacts
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds new method `get_project_artifacts()`.

Also adds `with_sbom_overview` to the two other artifact methods (`get_artifact()`, `get_artifacts()`).

Yeah, 2 changes in one PR. Deal with it.