### PR TITLE
Fix Pydantic 2.10.2 incompatibility issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
   "httpx>=0.22.0",
-  "pydantic>=2.2.1",
+  "pydantic>=2.2.1,<2.10.2",
   "backoff>=2.1.2",
   "typing_extensions>=4.4.0",
 ]


### PR DESCRIPTION
Fixes #99

Update the Pydantic dependency version range in `pyproject.toml` to exclude version 2.10.2.

* Change the dependency specification to `pydantic>=2.2.1,<2.10.2`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/unioslo/harborapi/pull/100?shareId=65a15ee3-a3fa-4ade-a45f-f812109a80e1).