### PR TITLE
Fix Pydantic dependency to avoid TypeError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
   "httpx>=0.22.0",
-  "pydantic>=2.2.1",
+  "pydantic>=2.2.1,<2.10.0",
   "backoff>=2.1.2",
   "typing_extensions>=4.4.0",
 ]


### PR DESCRIPTION
Fixes #99

Update the `pydantic` dependency in `pyproject.toml` to avoid compatibility issues with version 2.10.2.

* Change the `pydantic` dependency to `>=2.2.1,<2.10.0` in `pyproject.toml`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/unioslo/harborapi/pull/101?shareId=0fda9fc9-2239-4abc-9e93-e65e3f4fc23a).