### PR TITLE
Use latest `pypa/gh-action-pypi-publish` in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           path: dist
 
       - name: Push build artifacts to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.14
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
           user: __token__


### PR DESCRIPTION
Fixes failed PyPI push in CI.